### PR TITLE
feat: migrate all bitnami images to bitnamilegacy across entire build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -68,11 +68,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723991338,
-        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
+        "lastModified": 1773734432,
+        "narHash": "sha256-IF5ppUWh6gHGHYDbtVUyhwy/i7D261P7fWD1bPefOsw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
+        "rev": "cda48547b432e8d3b18b4180ba07473762ec8558",
         "type": "github"
       },
       "original": {

--- a/kubernetes/core/rabbitmq-operator.nix
+++ b/kubernetes/core/rabbitmq-operator.nix
@@ -11,7 +11,7 @@
       };
 
       values = {
-        global.imageRegistry = "docker.io/bitnamilegacy";
+        global.imageRegistry = "docker.io";
         clusterOperator.networkPolicy.enabled = false;
         msgTopologyOperator.networkPolicy.enabled = false;
       };

--- a/kubernetes/core/rabbitmq-operator.nix
+++ b/kubernetes/core/rabbitmq-operator.nix
@@ -12,8 +12,17 @@
 
       values = {
         global.imageRegistry = "docker.io";
-        clusterOperator.networkPolicy.enabled = false;
-        msgTopologyOperator.networkPolicy.enabled = false;
+        global.security.allowInsecureImages = true;
+        rabbitmqImage.repository = "bitnamilegacy/rabbitmq";
+        credentialUpdaterImage.repository = "bitnamilegacy/rmq-default-credential-updater";
+        clusterOperator = {
+          networkPolicy.enabled = false;
+          image.repository = "bitnamilegacy/rabbitmq-cluster-operator";
+        };
+        msgTopologyOperator = {
+          networkPolicy.enabled = false;
+          image.repository = "bitnamilegacy/rmq-messaging-topology-operator";
+        };
       };
 
       includeCRDs = true;

--- a/kubernetes/core/velero.nix
+++ b/kubernetes/core/velero.nix
@@ -11,6 +11,9 @@
       };
 
       values = {
+        kubectl.image.repository = "docker.io/bitnamilegacy/kubectl";
+        kubectl.image.tag = "1.33.4";
+
         initContainers = [
           {
             name = "velero-plugin-for-csi";

--- a/kubernetes/guiduck/redis.nix
+++ b/kubernetes/guiduck/redis.nix
@@ -12,6 +12,9 @@
 
       values = {
         global.imageRegistry = "docker.io";
+        global.security.allowInsecureImages = true;
+        image.repository = "bitnamilegacy/redis";
+        sentinel.image.repository = "bitnamilegacy/redis-sentinel";
         architecture = "standalone";
         usePassword = true;
         master = {
@@ -21,8 +24,14 @@
             limits = { memory = "1Gi"; cpu = "50m"; };
           };
         };
-        metrics.enabled = true;
+        metrics = {
+          enabled = true;
+          image.repository = "bitnamilegacy/redis-exporter";
+        };
         networkPolicy.enabled = false;
+        volumePermissions.image.repository = "bitnamilegacy/os-shell";
+        sysctl.image.repository = "bitnamilegacy/os-shell";
+        kubectl.image.repository = "bitnamilegacy/kubectl";
       };
     };
   };

--- a/kubernetes/guiduck/redis.nix
+++ b/kubernetes/guiduck/redis.nix
@@ -11,7 +11,7 @@
       };
 
       values = {
-        global.imageRegistry = "docker.io/bitnamilegacy";
+        global.imageRegistry = "docker.io";
         architecture = "standalone";
         usePassword = true;
         master = {

--- a/kubernetes/outline/outline.nix
+++ b/kubernetes/outline/outline.nix
@@ -39,10 +39,18 @@ in
 
       values = {
         global.imageRegistry = "docker.io";
+        image.repository = "bitnamilegacy/redis";
+        sentinel.image.repository = "bitnamilegacy/redis-sentinel";
         architecture = "standalone";
         master.persistence.size = "1Gi";
-        metrics.enabled = true;
+        metrics = {
+          enabled = true;
+          image.repository = "bitnamilegacy/redis-exporter";
+        };
         networkPolicy.enabled = false;
+        volumePermissions.image.repository = "bitnamilegacy/os-shell";
+        sysctl.image.repository = "bitnamilegacy/os-shell";
+        kubectl.image.repository = "bitnamilegacy/kubectl";
       };
     };
 

--- a/kubernetes/outline/outline.nix
+++ b/kubernetes/outline/outline.nix
@@ -39,6 +39,7 @@ in
 
       values = {
         global.imageRegistry = "docker.io";
+        global.security.allowInsecureImages = true;
         image.repository = "bitnamilegacy/redis";
         sentinel.image.repository = "bitnamilegacy/redis-sentinel";
         architecture = "standalone";

--- a/kubernetes/outline/outline.nix
+++ b/kubernetes/outline/outline.nix
@@ -38,7 +38,7 @@ in
       };
 
       values = {
-        global.imageRegistry = "docker.io/bitnamilegacy";
+        global.imageRegistry = "docker.io";
         architecture = "standalone";
         master.persistence.size = "1Gi";
         metrics.enabled = true;

--- a/kubernetes/poketwo-staging-private/redis.nix
+++ b/kubernetes/poketwo-staging-private/redis.nix
@@ -11,6 +11,9 @@
 
     values = {
       global.imageRegistry = "docker.io";
+      global.security.allowInsecureImages = true;
+      image.repository = "bitnamilegacy/redis";
+      sentinel.image.repository = "bitnamilegacy/redis-sentinel";
       architecture = "standalone";
       usePassword = true;
       master = {
@@ -20,8 +23,14 @@
           limits = { memory = "1Gi"; cpu = "20m"; };
         };
       };
-      metrics.enabled = true;
+      metrics = {
+        enabled = true;
+        image.repository = "bitnamilegacy/redis-exporter";
+      };
       networkPolicy.enabled = false;
+      volumePermissions.image.repository = "bitnamilegacy/os-shell";
+      sysctl.image.repository = "bitnamilegacy/os-shell";
+      kubectl.image.repository = "bitnamilegacy/kubectl";
     };
   };
 }

--- a/kubernetes/poketwo-staging-private/redis.nix
+++ b/kubernetes/poketwo-staging-private/redis.nix
@@ -10,7 +10,7 @@
     };
 
     values = {
-      global.imageRegistry = "docker.io/bitnamilegacy";
+      global.imageRegistry = "docker.io";
       architecture = "standalone";
       usePassword = true;
       master = {

--- a/kubernetes/poketwo-staging/redis.nix
+++ b/kubernetes/poketwo-staging/redis.nix
@@ -11,6 +11,9 @@
 
     values = {
       global.imageRegistry = "docker.io";
+      global.security.allowInsecureImages = true;
+      image.repository = "bitnamilegacy/redis";
+      sentinel.image.repository = "bitnamilegacy/redis-sentinel";
       architecture = "standalone";
       usePassword = true;
       master = {
@@ -20,8 +23,14 @@
           limits = { memory = "1Gi"; cpu = "20m"; };
         };
       };
-      metrics.enabled = true;
+      metrics = {
+        enabled = true;
+        image.repository = "bitnamilegacy/redis-exporter";
+      };
       networkPolicy.enabled = false;
+      volumePermissions.image.repository = "bitnamilegacy/os-shell";
+      sysctl.image.repository = "bitnamilegacy/os-shell";
+      kubectl.image.repository = "bitnamilegacy/kubectl";
     };
   };
 }

--- a/kubernetes/poketwo-staging/redis.nix
+++ b/kubernetes/poketwo-staging/redis.nix
@@ -10,7 +10,7 @@
     };
 
     values = {
-      global.imageRegistry = "docker.io/bitnamilegacy";
+      global.imageRegistry = "docker.io";
       architecture = "standalone";
       usePassword = true;
       master = {

--- a/kubernetes/poketwo/keycloak.nix
+++ b/kubernetes/poketwo/keycloak.nix
@@ -124,7 +124,7 @@ in
       };
 
       values = {
-        global.imageRegistry = "docker.io/bitnamilegacy";
+        global.imageRegistry = "docker.io";
         auth.existingSecret = "keycloak-auth";
         production = true;
         proxy = "edge";

--- a/kubernetes/poketwo/keycloak.nix
+++ b/kubernetes/poketwo/keycloak.nix
@@ -125,6 +125,8 @@ in
 
       values = {
         global.imageRegistry = "docker.io";
+        global.security.allowInsecureImages = true;
+        image.repository = "bitnamilegacy/keycloak";
         auth.existingSecret = "keycloak-auth";
         production = true;
         proxy = "edge";
@@ -132,6 +134,7 @@ in
         metrics.enabled = true;
         postgresql.enabled = false;
         networkPolicy.enabled = false;
+        keycloakConfigCli.image.repository = "bitnamilegacy/keycloak-config-cli";
 
         initContainers = [{
           name = "download-resources";

--- a/kubernetes/poketwo/keycloak.nix
+++ b/kubernetes/poketwo/keycloak.nix
@@ -134,8 +134,6 @@ in
         metrics.enabled = true;
         postgresql.enabled = false;
         networkPolicy.enabled = false;
-        keycloakConfigCli.image.repository = "bitnamilegacy/keycloak-config-cli";
-
         initContainers = [{
           name = "download-resources";
           image = "alpine/git";
@@ -182,6 +180,7 @@ in
           enabled = true;
           existingConfigmap = "keycloak-config-cli";
           cleanupAfterFinished.enabled = true;
+          image.repository = "bitnamilegacy/keycloak-config-cli";
         };
       };
     };

--- a/kubernetes/poketwo/mongodb.nix
+++ b/kubernetes/poketwo/mongodb.nix
@@ -42,7 +42,7 @@ in
       };
 
       values = {
-        global.imageRegistry = "docker.io/bitnamilegacy";
+        global.imageRegistry = "docker.io";
         architecture = "replicaset";
         auth = { enabled = true; existingSecret = "mongodb"; };
         replicaSetName = "poketwo";

--- a/kubernetes/poketwo/mongodb.nix
+++ b/kubernetes/poketwo/mongodb.nix
@@ -43,6 +43,8 @@ in
 
       values = {
         global.imageRegistry = "docker.io";
+        global.security.allowInsecureImages = true;
+        image.repository = "bitnamilegacy/mongodb";
         architecture = "replicaset";
         auth = { enabled = true; existingSecret = "mongodb"; };
         replicaSetName = "poketwo";
@@ -84,8 +86,16 @@ in
           };
         };
 
-        volumePermissions.enabled = true;
-        metrics.enabled = true;
+        volumePermissions = {
+          enabled = true;
+          image.repository = "bitnamilegacy/os-shell";
+        };
+        metrics = {
+          enabled = true;
+          image.repository = "bitnamilegacy/mongodb-exporter";
+        };
+        externalAccess.autoDiscovery.image.repository = "bitnamilegacy/kubectl";
+        tls.image.repository = "bitnamilegacy/nginx";
       };
     };
 

--- a/kubernetes/poketwo/mongodb.nix
+++ b/kubernetes/poketwo/mongodb.nix
@@ -66,6 +66,7 @@ in
         externalAccess = {
           enabled = true;
           autoDiscovery.enabled = true;
+          autoDiscovery.image.repository = "bitnamilegacy/kubectl";
 
           service = {
             annotations."external-dns.alpha.kubernetes.io/cloudflare-proxied" = "false";
@@ -94,7 +95,6 @@ in
           enabled = true;
           image.repository = "bitnamilegacy/mongodb-exporter";
         };
-        externalAccess.autoDiscovery.image.repository = "bitnamilegacy/kubectl";
         tls.image.repository = "bitnamilegacy/nginx";
       };
     };

--- a/kubernetes/poketwo/redis.nix
+++ b/kubernetes/poketwo/redis.nix
@@ -12,6 +12,9 @@
 
       values = {
         global.imageRegistry = "docker.io";
+        global.security.allowInsecureImages = true;
+        image.repository = "bitnamilegacy/redis";
+        sentinel.image.repository = "bitnamilegacy/redis-sentinel";
         architecture = "standalone";
         usePassword = true;
         master = {
@@ -21,8 +24,14 @@
             limits = { memory = "30Gi"; cpu = "1000m"; };
           };
         };
-        metrics.enabled = true;
+        metrics = {
+          enabled = true;
+          image.repository = "bitnamilegacy/redis-exporter";
+        };
         networkPolicy.enabled = false;
+        volumePermissions.image.repository = "bitnamilegacy/os-shell";
+        sysctl.image.repository = "bitnamilegacy/os-shell";
+        kubectl.image.repository = "bitnamilegacy/kubectl";
       };
     };
   };

--- a/kubernetes/poketwo/redis.nix
+++ b/kubernetes/poketwo/redis.nix
@@ -11,7 +11,7 @@
       };
 
       values = {
-        global.imageRegistry = "docker.io/bitnamilegacy";
+        global.imageRegistry = "docker.io";
         architecture = "standalone";
         usePassword = true;
         master = {


### PR DESCRIPTION
## Summary

Migrates **all** bitnami Helm chart images across every namespace to use the `bitnamilegacy` Docker Hub organization, replacing the broken `global.imageRegistry = "docker.io/bitnamilegacy"` approach (which produced invalid paths like `docker.io/bitnamilegacy/bitnami/redis`) with per-image `repository` overrides.

Also updates `flake.lock` to a newer nixpkgs to fix a Helm version incompatibility with the redis 21.1.4 chart (old Helm 3.15.4 failed with `invalid_reference: invalid tag`).

### Changes by namespace

| Namespace | Chart | Images overridden |
|-----------|-------|-------------------|
| outline | redis 19.6.1 | redis, redis-sentinel, redis-exporter, os-shell, kubectl |
| guiduck | redis 21.1.4 | redis, redis-sentinel, redis-exporter, os-shell, kubectl |
| poketwo | redis 19.6.1 | redis, redis-sentinel, redis-exporter, os-shell, kubectl |
| poketwo | mongodb 15.6.12 | mongodb, mongodb-exporter, os-shell, kubectl, nginx (tls) |
| poketwo | keycloak 21.6.1 | keycloak, keycloak-config-cli |
| poketwo-staging | redis 19.6.1 | redis, redis-sentinel, redis-exporter, os-shell, kubectl |
| poketwo-staging-private | redis 19.6.1 | redis, redis-sentinel, redis-exporter, os-shell, kubectl |
| rabbitmq-operator | rabbitmq-cluster-operator 4.3.18 | rabbitmq-cluster-operator, rmq-messaging-topology-operator, rabbitmq, rmq-default-credential-updater |
| velero | velero 6.7.0 (non-bitnami chart) | kubectl (pinned to 1.33.4 since 1.34 doesn't exist on bitnamilegacy) |

### Other changes

- **`global.security.allowInsecureImages = true`** added to all bitnami Helm charts — newer chart versions (e.g. redis 21.1.4) reject non-standard images at template time without this flag.
- **`flake.lock`**: nixpkgs bumped from `8a33541` (Aug 2024) → `cda4854` (Mar 2026).

### Updates since last revision

- Fixed duplicate Nix attribute definitions caught by review bot:
  - **keycloak.nix**: moved `keycloakConfigCli.image.repository` inside the existing `keycloakConfigCli = { ... }` block (was a separate dotted-path assignment that would conflict).
  - **mongodb.nix**: moved `externalAccess.autoDiscovery.image.repository` inside the existing `externalAccess = { ... }` block (same issue).

### Verification performed

- `nix build .#kubernetes` compiles successfully
- Zero remaining `bitnami/` (non-legacy) image references in the entire build output
- All 13 unique `bitnamilegacy/` images confirmed pullable on Docker Hub

## Review & Testing Checklist for Human

- [ ] **Verify the nixpkgs bump is acceptable.** This is a ~1.5 year jump — check that other derivations (transpire, agenix, host configs) still behave correctly. Consider whether a more targeted fix (e.g., overlaying just the helm package) would be less risky.
- [ ] **Spot-check rendered YAML** by running `nix build .#kubernetes` and inspecting `result/` directories for each namespace. Confirm all image references are correct, especially for mongodb (which has kubectl, os-shell, mongodb-exporter, and nginx overrides across multiple sub-blocks) and keycloak (keycloak-config-cli inside the existing block).
- [ ] **Verify the velero kubectl pin to 1.33.4** is acceptable. The chart default was `bitnami/kubectl:1.34` which doesn't exist on bitnamilegacy; it's been pinned to `1.33.4` instead. Confirm this kubectl version is compatible with your cluster.
- [ ] **Deploy to a test cluster** and verify pods in all affected namespaces can pull images and start successfully — especially mongodb (replicaset with external access + arbiter) and keycloak (config-cli job + init containers).

### Notes
- The `global.security.allowInsecureImages = true` flag disables Helm's built-in image origin verification. This is required for bitnamilegacy images but worth being aware of.
- The bitnamilegacy Docker Hub org is marked as "no longer updated" — these are frozen legacy images with no future security patches. Plan for a long-term migration path.
- The mongodb chart has `tls.image.repository = "bitnamilegacy/nginx"` overridden even though TLS isn't explicitly enabled — this is a defensive override to prevent any default bitnami/ reference from leaking through.

Link to Devin session: https://app.devin.ai/sessions/6193c27a83d647b3ac94707095e7386a
Requested by: @WitherredAway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
