### PR TITLE
chore: update agenix and transpire flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1723293904,
-        "narHash": "sha256-b+uqzj+Wa6xgMS9aNbX4I+sXeb5biPDi39VgvSFqFvU=",
+        "lastModified": 1770165109,
+        "narHash": "sha256-9VnK6Oqai65puVJ4WYtCTvlJeXxMzAp/69HhQuTdl/I=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "f6291c5935fdc4e0bef208cfc0dcab7e3f7a1c41",
+        "rev": "b027ee29d959fda4b60b57566d64c98a202e0feb",
         "type": "github"
       },
       "original": {
@@ -31,11 +31,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700795494,
-        "narHash": "sha256-gzGLZSiOhf155FW7262kdHo2YDeugp3VuIFb4/GGng0=",
+        "lastModified": 1744478979,
+        "narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "4b9b83d5a92e8c1fbfd8eb27eda375908c11ec4d",
+        "rev": "43975d782b418ebf4969e9ccba82466728c2851b",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703113217,
-        "narHash": "sha256-7ulcXOk63TIT2lVDSExj7XzFx09LpdSAPtvgtM7yQPE=",
+        "lastModified": 1745494811,
+        "narHash": "sha256-YZCh2o9Ua1n9uCvrvi5pRxtuVNml8X2a03qIFfRKpFs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3bfaacf46133c037bb356193bd2f1765d9dc82c1",
+        "rev": "abfad3d2958c9e6300a883bd443512c55dfeb1be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Updates the `agenix` flake input from 2024-08-10 to 2026-02-04 to fix the build-breaking error:

```
error: `substituteAll` has been removed. Use `replaceVars` instead.
```

This broke after nixpkgs was updated to a March 2026 revision in PR #2, but `agenix` was left pinned to an old version that still used the removed `substituteAll` function. Since `agenix.inputs.nixpkgs` follows root nixpkgs, the old agenix code is incompatible with the new nixpkgs.

Also updates agenix's transitive dependencies (nix-darwin, home-manager). Note: `transpire` was **not** updated by this change despite being targeted — it was likely already compatible.

## Review & Testing Checklist for Human

- [ ] **Verify the build works**: Run `nix develop -c colmena build --on glaceon --on sylveon` (or any host) to confirm the `substituteAll` error is resolved. CI does not run on PRs.
- [ ] **Check for agenix breaking changes**: agenix jumped from `f6291c5` (Aug 2024) to `b027ee2` (Feb 2026) — ~1.5 years of changes. Skim the [agenix changelog/commits](https://github.com/ryantm/agenix/compare/f6291c5935fdc4e0bef208cfc0dcab7e3f7a1c41...b027ee29d959fda4b60b57566d64c98a202e0feb) for any breaking changes that might affect secret decryption or the module interface.
- [ ] **Re-encrypt secrets if needed**: If agenix changed its encryption/decryption behavior, you may need to run `agenix -r` after merging.

### Notes
- The commit message mentions updating transpire, but transpire's lock entry is unchanged in the diff — it was already compatible with the current nixpkgs.
- `nixpkgs` itself is not changed by this PR (stays at the March 2026 revision from PR #2).

Link to Devin session: https://app.devin.ai/sessions/506280557c4d4e6ead5d16b127d5bef5
Requested by: @oliver-ni