### PR TITLE
feat: add dedicated deploy user and remove buildOnTarget

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
         agenix.nixosModules.default
         ./modules/poketwo/auth.nix
         ./modules/poketwo/cloudflare-warp.nix
+        ./modules/poketwo/deploy.nix
         ./modules/poketwo/kubernetes.nix
         ./modules/poketwo/locale.nix
         ./modules/poketwo/nat64.nix
@@ -78,7 +79,7 @@
           imports = commonModules ++ modules;
           deployment.buildOnTarget = true;
           deployment.targetHost = "${host}.hfym.co";
-          deployment.targetUser = "oliver";
+          deployment.targetUser = "deploy";
           deployment.allowLocalDeployment = true;
         })
         hosts;

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,6 @@
       colmenaHosts = builtins.mapAttrs
         (host: modules: {
           imports = commonModules ++ modules;
-          deployment.buildOnTarget = false;
           deployment.targetHost = "${host}.hfym.co";
           deployment.targetUser = "deploy";
           deployment.allowLocalDeployment = true;

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
       colmenaHosts = builtins.mapAttrs
         (host: modules: {
           imports = commonModules ++ modules;
-          deployment.buildOnTarget = true;
+          deployment.buildOnTarget = false;
           deployment.targetHost = "${host}.hfym.co";
           deployment.targetUser = "deploy";
           deployment.allowLocalDeployment = true;

--- a/modules/poketwo/deploy.nix
+++ b/modules/poketwo/deploy.nix
@@ -1,0 +1,43 @@
+{ lib, config, ... }:
+
+let
+  cfg = config.poketwo.deploy;
+  deploy-user = "deploy";
+in
+{
+  options.poketwo.deploy = {
+    enable = lib.mkEnableOption "Enable dedicated deploy user for Colmena";
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${deploy-user} = {
+      isNormalUser = true;
+      createHome = false;
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGlViRB5HH1bTaS1S7TcqVBSuxKdrbdhL2CmhDqc/t6A oliver.ni@gmail.com"
+      ];
+    };
+
+    nix.settings.trusted-users = [ deploy-user ];
+
+    security.sudo.extraRules = [
+      {
+        users = [ deploy-user ];
+        commands = [
+          {
+            command = "/run/current-system/sw/bin/nix-store --no-gc-warning --realise /nix/store/*";
+            options = [ "NOPASSWD" ];
+          }
+          {
+            command = "/run/current-system/sw/bin/nix-env --profile /nix/var/nix/profiles/system --set /nix/store/*";
+            options = [ "NOPASSWD" ];
+          }
+          {
+            command = "/nix/store/*/bin/switch-to-configuration *";
+            options = [ "NOPASSWD" ];
+          }
+        ];
+      }
+    ];
+  };
+}

--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -17,6 +17,7 @@
 
   poketwo = {
     auth.enable = lib.mkDefault true;
+    deploy.enable = lib.mkDefault true;
     locale.enable = lib.mkDefault true;
     nat64.enable = lib.mkDefault true;
     shell.enable = lib.mkDefault true;


### PR DESCRIPTION
## Summary

Adds a dedicated `deploy` user for Colmena deployments instead of using `oliver`'s personal account. The deploy user has minimal sudo permissions scoped to only the three commands Colmena needs:
- `nix-store --realise` — realise store paths
- `nix-env --set` — update the system profile
- `switch-to-configuration` — activate the new config

The user is added to `nix.settings.trusted-users` so Colmena can copy closures to the nix store. Pattern adapted from [ocf/nix `managed-deployment.nix`](https://github.com/ocf/nix/blob/main/modules/managed-deployment.nix).

Also removes `deployment.buildOnTarget = true` entirely from the flake so Colmena builds locally by default (colmena's own default). Pass `--build-on-target` manually when needed.

## Review & Testing Checklist for Human

- [ ] **Chicken-and-egg deployment**: After merging, the `deploy` user won't exist on servers yet. The first apply **must** be done with `--ssh-user oliver` to bootstrap the deploy user. Verify you have a plan for this before merging.
- [ ] **Sudo wildcard patterns**: The rules use globs like `/nix/store/*` and `*/bin/switch-to-configuration *`. Verify these don't allow unintended command execution beyond what Colmena needs.
- [ ] **`trusted-users` scope**: Adding `deploy` to `nix.settings.trusted-users` grants broad Nix daemon access (arbitrary substituters, signing keys, etc.). This is required for Colmena but worth noting as a security surface.
- [ ] **Test plan**: Bootstrap by running `nix develop -c colmena apply --on <one-host> -- --ssh-user oliver`, then verify the `deploy` user exists and subsequent deploys work without `--ssh-user`.

### Notes
- The module follows the existing `poketwo.*` option pattern (`mkEnableOption`, `mkIf`, enabled via `profiles/base.nix`).
- `createHome = false` since the deploy user doesn't need a home directory.
- The deploy user's SSH key is hardcoded to `oliver.ni@gmail.com`. If CI-driven deploys are planned later, a separate deploy key would be needed.

Link to Devin session: https://app.devin.ai/sessions/506280557c4d4e6ead5d16b127d5bef5
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
