### PR TITLE
fix: increase nginx proxy buffer size for keycloak ingress

### DIFF
--- a/kubernetes/poketwo/keycloak.nix
+++ b/kubernetes/poketwo/keycloak.nix
@@ -145,6 +145,8 @@ in
         ingress = {
           enabled = true;
           annotations."cert-manager.io/cluster-issuer" = "letsencrypt";
+          annotations."nginx.ingress.kubernetes.io/proxy-buffer-size" = "128k";
+          annotations."nginx.ingress.kubernetes.io/proxy-buffers-number" = "4";
           hostname = "auth-dev.poketwo.io";
           tls = true;
         };


### PR DESCRIPTION
## Summary

Fixes `upstream sent too big header while reading response header from upstream` 502 errors on `auth-dev.poketwo.io` by adding nginx ingress annotations to increase proxy buffer sizes.

Keycloak's OIDC auth redirects (especially Google's) produce very large response headers that exceed nginx's default 4k/8k proxy buffer size, causing 502s. This adds:
- `proxy-buffer-size: 128k` — increases the buffer for reading the first part of the upstream response header
- `proxy-buffers-number: 4` — number of buffers used for reading the response

## Review & Testing Checklist for Human

- [ ] After deploying, verify that the Google OIDC login flow on `auth-dev.poketwo.io` no longer returns 502 errors
- [ ] Monitor nginx error logs to confirm no more "upstream sent too big header" messages
- [ ] Check that 128k buffer size is appropriate — if headers are still too large, may need to increase further

### Notes
- 128k is a commonly recommended buffer size for Keycloak behind nginx ingress; the default is typically 4k which is far too small for OIDC flows with long state/code_challenge parameters

Link to Devin session: https://app.devin.ai/sessions/5882c05bead440ee97e988016b24660b
Requested by: @oliver-ni