### PR TITLE
fix: disable HTTP/2 in Nix to avoid stream errors in CI

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -20,6 +20,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            http2 = false
       - name: Check Nix flake inputs
         uses: DeterminateSystems/flake-checker-action@v10
 


### PR DESCRIPTION
## Summary

Disables HTTP/2 in the Nix daemon during CI builds by passing `http2 = false` via `extra-conf` to `determinate-nix-action`. This works around intermittent `Stream error in the HTTP/2 framing layer` / `INTERNAL_ERROR (err 2)` curl errors when downloading from `install.determinate.systems` and other Nix substituters.

This is a [known issue](https://github.com/NixOS/nix/issues/13074) with curl's HTTP/2 implementation and certain cache servers.

## Review & Testing Checklist for Human

- [ ] **Performance tradeoff**: This disables HTTP/2 for *all* Nix downloads in CI (not just `install.determinate.systems`), falling back to HTTP/1.1. Verify that the build time increase (due to loss of HTTP/2 multiplexing) is acceptable vs. the reliability gain.
- [ ] **Scope check**: Consider whether this should be a permanent fix or a temporary workaround — if Determinate Systems fixes their server-side HTTP/2 handling, this could be reverted to restore performance.
- [ ] **Verify CI**: Merge and confirm that the next CI run on `main` completes without HTTP/2 stream errors.

### Notes

- The `http2` Nix config option is documented in the [Nix manual](https://manual.determinate.systems/command-ref/conf-file.html). Setting it to `false` forces HTTP/1.1 for all downloads.
- An alternative approach would be to remove `install.determinate.systems` from substituters entirely, but that would lose the cache benefits. Disabling HTTP/2 is the less disruptive option.

Link to Devin session: https://app.devin.ai/sessions/5882c05bead440ee97e988016b24660b
Requested by: @oliver-ni