### PR TITLE
feat: migrate from Colmena to deploy-rs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,59 @@
+name: Build NixOS Hosts
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-flake:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+      - name: Check Nix flake inputs
+        uses: DeterminateSystems/flake-checker-action@v10
+
+  hosts:
+    runs-on: ubuntu-latest
+    outputs:
+      hosts: ${{ steps.list.outputs.hosts }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+      - name: List hosts
+        id: list
+        run: |
+          hosts=$(nix eval --json .#nixosConfigurations --apply 'x: builtins.attrNames x')
+          echo "hosts=$hosts" >> "$GITHUB_OUTPUT"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [check-flake, hosts]
+    strategy:
+      fail-fast: false
+      matrix:
+        host: ${{ fromJson(needs.hosts.outputs.hosts) }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ matrix.host }}-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: |
+            nix-${{ matrix.host }}-
+          gc-max-store-size-linux: 4000000000
+      - name: Build ${{ matrix.host }}
+        run: nix build .#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,4 +56,6 @@ jobs:
             nix-${{ matrix.host }}-
           gc-max-store-size-linux: 4000000000
       - name: Build ${{ matrix.host }}
-        run: nix build .#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel
+        run: nix build ".#nixosConfigurations.$HOST.config.system.build.toplevel"
+        env:
+          HOST: ${{ matrix.host }}

--- a/flake.lock
+++ b/flake.lock
@@ -45,6 +45,44 @@
         "type": "github"
       }
     },
+    "deploy-rs": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1770019181,
+        "narHash": "sha256-hwsYgDnby50JNVpTRYlF3UR/Rrpt01OrxVuryF40CFY=",
+        "ref": "refs/heads/master",
+        "rev": "77c906c0ba56aabdbc72041bf9111b565cdd6171",
+        "revCount": 348,
+        "type": "git",
+        "url": "https://github.com/serokell/deploy-rs"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://github.com/serokell/deploy-rs"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -85,8 +123,9 @@
     "root": {
       "inputs": {
         "agenix": "agenix",
+        "deploy-rs": "deploy-rs",
         "nixpkgs": "nixpkgs",
-        "systems": "systems_2",
+        "systems": "systems_3",
         "transpire": "transpire"
       }
     },
@@ -135,12 +174,27 @@
         "type": "github"
       }
     },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "transpire": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_3"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1722117965,
@@ -153,6 +207,24 @@
       "original": {
         "owner": "oliver-ni",
         "repo": "transpire",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -56,15 +56,15 @@
       "locked": {
         "lastModified": 1770019181,
         "narHash": "sha256-hwsYgDnby50JNVpTRYlF3UR/Rrpt01OrxVuryF40CFY=",
-        "ref": "refs/heads/master",
+        "owner": "serokell",
+        "repo": "deploy-rs",
         "rev": "77c906c0ba56aabdbc72041bf9111b565cdd6171",
-        "revCount": 348,
-        "type": "git",
-        "url": "https://github.com/serokell/deploy-rs"
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "https://github.com/serokell/deploy-rs"
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "type": "github"
       }
     },
     "flake-compat": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     systems.url = "github:nix-systems/default";
     agenix.url = "github:ryantm/agenix";
-    deploy-rs.url = "git+https://github.com/serokell/deploy-rs";
+    deploy-rs.url = "github:serokell/deploy-rs";
     transpire.url = "github:oliver-ni/transpire";
     # transpire.url = "path:/Users/oliver/Development/github.com/oliver-ni/transpire-nix";
 

--- a/flake.nix
+++ b/flake.nix
@@ -78,29 +78,30 @@
     {
       formatter = forAllSystems (system: pkgs: pkgs.nixpkgs-fmt);
 
-      # ========================
-      # deploy-rs Configuration
-      # ========================
-
       nixosConfigurations = builtins.mapAttrs
         (host: modules: nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
           specialArgs = { inherit inputs; };
-          modules = commonModules ++ modules;
+          modules = commonModules ++ modules ++ [
+            { nixpkgs.overlays = overlays; nixpkgs.config.allowUnfree = true; }
+          ];
         })
         hosts;
 
+      # ========================
+      # deploy-rs Configuration
+      # ========================
+
       deploy.nodes = builtins.mapAttrs
-        (host: _: {
+        (host: nixosConfig: {
           hostname = "${host}.hfym.co";
           profiles.system = {
             user = "root";
             sshUser = "oliver";
-            path = deploy-rs.lib.x86_64-linux.activate.nixos
-              self.nixosConfigurations.${host};
+            path = deploy-rs.lib.x86_64-linux.activate.nixos nixosConfig;
           };
         })
-        hosts;
+        self.nixosConfigurations;
 
       checks = builtins.mapAttrs
         (system: deployLib: deployLib.deployChecks self.deploy)

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,10 @@
     {
       formatter = forAllSystems (system: pkgs: pkgs.nixpkgs-fmt);
 
+      # ========================
+      # deploy-rs Configuration
+      # ========================
+
       nixosConfigurations = builtins.mapAttrs
         (host: modules: nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";

--- a/flake.nix
+++ b/flake.nix
@@ -5,14 +5,16 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     systems.url = "github:nix-systems/default";
     agenix.url = "github:ryantm/agenix";
+    deploy-rs.url = "git+https://github.com/serokell/deploy-rs";
     transpire.url = "github:oliver-ni/transpire";
     # transpire.url = "path:/Users/oliver/Development/github.com/oliver-ni/transpire-nix";
 
     agenix.inputs.nixpkgs.follows = "nixpkgs";
+    deploy-rs.inputs.nixpkgs.follows = "nixpkgs";
     transpire.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, systems, agenix, transpire, ... }@inputs:
+  outputs = { self, nixpkgs, systems, agenix, deploy-rs, transpire, ... }@inputs:
     let
       # ========================
       # NixOS Host Configuration
@@ -69,20 +71,6 @@
         config = { allowUnfree = true; };
       };
 
-      # =====================
-      # Colmena Configuration
-      # =====================
-
-      colmenaHosts = builtins.mapAttrs
-        (host: modules: {
-          imports = commonModules ++ modules;
-          deployment.buildOnTarget = true;
-          deployment.targetHost = "${host}.hfym.co";
-          deployment.targetUser = "oliver";
-          deployment.allowLocalDeployment = true;
-        })
-        hosts;
-
       forAllSystems = fn: nixpkgs.lib.genAttrs
         (import systems)
         (system: fn system (pkgsFor system));
@@ -90,16 +78,33 @@
     {
       formatter = forAllSystems (system: pkgs: pkgs.nixpkgs-fmt);
 
-      colmena = colmenaHosts // {
-        meta = {
-          nixpkgs = pkgsFor "x86_64-linux";
+      nixosConfigurations = builtins.mapAttrs
+        (host: modules: nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
           specialArgs = { inherit inputs; };
-        };
-      };
+          modules = commonModules ++ modules;
+        })
+        hosts;
+
+      deploy.nodes = builtins.mapAttrs
+        (host: _: {
+          hostname = "${host}.hfym.co";
+          profiles.system = {
+            user = "root";
+            sshUser = "oliver";
+            path = deploy-rs.lib.x86_64-linux.activate.nixos
+              self.nixosConfigurations.${host};
+          };
+        })
+        hosts;
+
+      checks = builtins.mapAttrs
+        (system: deployLib: deployLib.deployChecks self.deploy)
+        deploy-rs.lib;
 
       devShells = forAllSystems (system: pkgs: {
         default = pkgs.mkShell {
-          packages = [ pkgs.colmena pkgs.agenix ];
+          packages = [ pkgs.deploy-rs pkgs.agenix ];
         };
       });
 

--- a/flake.nix
+++ b/flake.nix
@@ -58,22 +58,9 @@
 
       openApiSpec = ./kube-openapi.json;
 
-      # =====================
-      # nixpkgs Configuration
-      # =====================
-
-      overlays = [
-        agenix.overlays.default
-      ];
-
-      pkgsFor = system: import nixpkgs {
-        inherit overlays system;
-        config = { allowUnfree = true; };
-      };
-
       forAllSystems = fn: nixpkgs.lib.genAttrs
         (import systems)
-        (system: fn system (pkgsFor system));
+        (system: fn system (import nixpkgs { inherit system; }));
     in
     {
       formatter = forAllSystems (system: pkgs: pkgs.nixpkgs-fmt);
@@ -82,9 +69,10 @@
         (host: modules: nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
           specialArgs = { inherit inputs; };
-          modules = commonModules ++ modules ++ [
-            { nixpkgs.overlays = overlays; nixpkgs.config.allowUnfree = true; }
-          ];
+          modules = commonModules ++ modules ++ [{
+            nixpkgs.overlays = [ agenix.overlays.default ];
+            nixpkgs.config.allowUnfree = true;
+          }];
         })
         hosts;
 
@@ -109,7 +97,10 @@
 
       devShells = forAllSystems (system: pkgs: {
         default = pkgs.mkShell {
-          packages = [ pkgs.deploy-rs pkgs.agenix ];
+          packages = [
+            deploy-rs.packages.${system}.default
+            agenix.packages.${system}.default
+          ];
         };
       });
 

--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -47,7 +47,7 @@
     systemPackages = with pkgs; [ vim htop dig wget curl ];
 
     etc."nixos/configuration.nix".text = ''
-      {}: builtins.abort "This machine is not managed by /etc/nixos. Please use colmena instead."
+      {}: builtins.abort "This machine is not managed by /etc/nixos. Please use deploy-rs instead."
     '';
   };
 }


### PR DESCRIPTION
## Summary

Replaces Colmena with [deploy-rs](https://github.com/serokell/deploy-rs) as the NixOS deployment tool. NixOS host configurations now live under the standard `nixosConfigurations` flake output (usable by any Nix tooling), with deployment metadata kept separate in the `deploy` output.

**flake.nix:**
- Removed `colmena` output, `colmenaHosts` helper, `pkgsFor`, and `overlays` variables
- Added `nixosConfigurations` output (standard `nixpkgs.lib.nixosSystem`) with overlays and `allowUnfree` configured via the NixOS module system (idiomatic approach, replacing the old externally-imported `pkgsFor` pattern)
- Added `deploy.nodes` output that derives directly from `self.nixosConfigurations`, keeping deployment metadata (hostname, sshUser, activation wrapper) cleanly separated
- Added `checks` output via `deploy-rs.lib.*.deployChecks`
- devShell now references `deploy-rs` and `agenix` packages directly from flake inputs instead of through pkgs/overlays

**CI:** Added `.github/workflows/build.yaml` with per-host matrix builds using `nix build .#nixosConfigurations.<host>.config.system.build.toplevel`. Matrix host value is passed via env var to prevent script injection.

**Usage change:** `colmena apply` → `deploy` (or `deploy .#host` for a single host).

## Review & Testing Checklist for Human

- [ ] **Test a real deployment** — Run `nix develop` then `deploy .#<host>` against a test host to verify the activation wrapper and magic rollback work correctly. This PR was **not tested against live servers**.
- [ ] **Verify `sshUser = "oliver"`** — Carried over from the Colmena config. Confirm this is still the desired SSH user for deployments (vs. a dedicated deploy user).
- [ ] **First deploy will cause a full rebuild** — Since nixpkgs configuration moved from external `pkgsFor` to the module system, store paths will differ from what's currently deployed. The first `deploy` after merging will likely rebuild/redownload most packages on the target hosts. This is a one-time cost.
- [ ] **`x86_64-linux` hardcoded** in `deploy-rs.lib.x86_64-linux.activate.nixos` — Fine for current infra but won't automatically extend to other architectures.

### Notes
- `buildOnTarget` was removed (as previously requested) — deploy-rs builds locally by default
- The existing `build-and-deploy.yaml` (Kubernetes CI) is untouched
- `deploy-rs` supports magic rollback by default (240s activation timeout, 30s confirm timeout) — configurable per-node/profile if needed

Link to Devin session: https://app.devin.ai/sessions/506280557c4d4e6ead5d16b127d5bef5
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
