### PR TITLE
feat: add disko config for jolteon boot disk

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,6 +67,27 @@
         "type": "github"
       }
     },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773889306,
+        "narHash": "sha256-PAqwnsBSI9SVC2QugvQ3xeYCB0otOwCacB1ueQj2tgw=",
+        "ref": "refs/heads/master",
+        "rev": "5ad85c82cc52264f4beddc934ba57f3789f28347",
+        "revCount": 1352,
+        "type": "git",
+        "url": "https://github.com/nix-community/disko"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -140,6 +161,7 @@
       "inputs": {
         "agenix": "agenix",
         "deploy-rs": "deploy-rs",
+        "disko": "disko",
         "nixpkgs": "nixpkgs",
         "nixpkgs-k8s": "nixpkgs-k8s",
         "systems": "systems_3",

--- a/flake.nix
+++ b/flake.nix
@@ -6,16 +6,18 @@
     nixpkgs-k8s.url = "github:nixos/nixpkgs/882842d2a908700540d206baa79efb922ac1c33d";
     systems.url = "github:nix-systems/default";
     agenix.url = "github:ryantm/agenix";
+    disko.url = "github:nix-community/disko";
     deploy-rs.url = "github:serokell/deploy-rs";
     transpire.url = "github:oliver-ni/transpire";
     # transpire.url = "path:/Users/oliver/Development/github.com/oliver-ni/transpire-nix";
 
     agenix.inputs.nixpkgs.follows = "nixpkgs";
+    disko.inputs.nixpkgs.follows = "nixpkgs";
     deploy-rs.inputs.nixpkgs.follows = "nixpkgs";
     transpire.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, systems, agenix, deploy-rs, transpire, ... }@inputs:
+  outputs = { self, nixpkgs, systems, agenix, disko, deploy-rs, transpire, ... }@inputs:
     let
       # ========================
       # NixOS Host Configuration
@@ -24,6 +26,7 @@
       # Put modules common to all hosts here.
       commonModules = [
         agenix.nixosModules.default
+        disko.nixosModules.default
         ./modules/poketwo/auth.nix
         ./modules/poketwo/cloudflare-warp.nix
         ./modules/poketwo/deploy.nix

--- a/hardware/jolteon.nix
+++ b/hardware/jolteon.nix
@@ -3,11 +3,66 @@
 {
   imports = [
     ./presets/gigabyte-r163-z30.nix
-    ./presets/zfs-root.nix
   ];
 
-  fileSystems."/boot" = {
-    device = "/dev/disk/by-uuid/E9C3-546F";
-    fsType = "vfat";
+  disko.devices = {
+    disk.boot = {
+      type = "disk";
+      device = "/dev/disk/by-path/pci-0000:05:00.0-nvme-1";
+      content = {
+        type = "gpt";
+        partitions = {
+          ESP = {
+            size = "1G";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+              mountOptions = [ "umask=0077" ];
+            };
+          };
+          zfs = {
+            size = "100%";
+            content = {
+              type = "zfs";
+              pool = "nixos";
+            };
+          };
+        };
+      };
+    };
+
+    zpool.nixos = {
+      type = "zpool";
+      options.cachefile = "none";
+      rootFsOptions = {
+        compression = "zstd";
+        mountpoint = "legacy";
+      };
+
+      datasets = {
+        root = {
+          type = "zfs_fs";
+          mountpoint = "/";
+          options.mountpoint = "legacy";
+        };
+        nix = {
+          type = "zfs_fs";
+          mountpoint = "/nix";
+          options.mountpoint = "legacy";
+        };
+        var = {
+          type = "zfs_fs";
+          mountpoint = "/var";
+          options.mountpoint = "legacy";
+        };
+        home = {
+          type = "zfs_fs";
+          mountpoint = "/home";
+          options.mountpoint = "legacy";
+        };
+      };
+    };
   };
 }

--- a/hardware/jolteon.nix
+++ b/hardware/jolteon.nix
@@ -35,10 +35,16 @@
 
     zpool.nixos = {
       type = "zpool";
-      options.cachefile = "none";
+      options = {
+        ashift = "12";
+        cachefile = "none";
+      };
       rootFsOptions = {
+        acltype = "posix";
+        atime = "off";
         compression = "zstd";
         mountpoint = "legacy";
+        xattr = "sa";
       };
 
       datasets = {


### PR DESCRIPTION
## Summary

Adds [disko](https://github.com/nix-community/disko) as a flake input and replaces jolteon's manual filesystem/boot config with a declarative disko disk layout. This prepares jolteon for reinstallation with a new boot disk (Samsung 990 PRO 1TB in NVMe slot `pci-0000:05:00.0-nvme-1`).

**What changed:**
- Added `disko` flake input (follows nixpkgs)
- Added `disko.nixosModules.default` to `commonModules` (no-op for hosts without `disko.devices`)
- Replaced jolteon's `zfs-root.nix` import + manual `/boot` fileSystems entry with inline disko config: GPT partition table with 1G EFI + ZFS partition, `nixos` pool with `root`, `nix`, `var`, `home` datasets (all `mountpoint=legacy`)
- Added recommended ZFS pool tuning options: `ashift=12` (4K sector alignment), `xattr=sa` (store xattrs in inodes), `acltype=posix` (enable POSIX ACLs), `atime=off` (disable access time updates)
- `/boot` now mounts with `umask=0077` (restricts boot files to root only, matching current NixOS best practice)

**To reinstall jolteon:**
```bash
disko-install --flake .#jolteon --disk boot /dev/disk/by-path/pci-0000:05:00.0-nvme-1
```

## Review & Testing Checklist for Human

- [ ] **Verify the device path** — `/dev/disk/by-path/pci-0000:05:00.0-nvme-1` points to the correct NVMe slot on jolteon (the new Samsung 990 PRO, not a Ceph disk). Confirm with `ls -la /dev/disk/by-path/ | grep nvme3n1` on the server.
- [ ] **Verify the lock file `disko` entry** — It was locked via `git+https` override (to bypass GitHub API rate limit), so `locked.type` is `"git"` instead of `"github"`. Consider running `nix flake lock --update-input disko` to re-lock with the proper `github` type before merging.
- [ ] **ZFS pool options** — `ashift=12` is set explicitly even though the 990 PRO reports 512B physical sectors. This is intentional (flash pages are 4K internally) and matches the existing `zpool create` command in your setup doc. `compression=zstd`, `xattr=sa`, `acltype=posix`, `atime=off` are new compared to the old config — confirm these are desired.
- [ ] **Test `disko-install`** — This config has not been tested against real hardware. Boot jolteon from a NixOS installer ISO and run the `disko-install` command above. Verify partitioning + install completes successfully and that the Ceph NVMe disks are untouched.

### Notes
- Only jolteon uses disko for now. Other hosts still use `zfs-root.nix` + manual `/boot` entries.
- The `mongo` ZFS pool (jolteon's data pool) is managed separately in `hosts/jolteon.nix` via `boot.zfs.extraPools` and is unaffected by this change.
- Compared to the old config, disko identifies `/boot` via `/dev/disk/by-partlabel/disk-boot-ESP` (created by disko during partitioning) instead of `/dev/disk/by-uuid/...`. This is expected — the UUID doesn't exist yet since this is a new disk.

Link to Devin session: https://app.devin.ai/sessions/506280557c4d4e6ead5d16b127d5bef5
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
