### PR TITLE
fix: resolve deprecation warnings (routeConfig, StartLimitInterval, system)

### DIFF
--- a/hosts/chimchar.nix
+++ b/hosts/chimchar.nix
@@ -29,8 +29,8 @@
         "2600:3c01::f03c:94ff:fe23:6eb3/64"
       ];
       routes = [
-        { routeConfig.Gateway = "50.116.4.1"; }
-        { routeConfig.Gateway = "fe80::1"; }
+        { Gateway = "50.116.4.1"; }
+        { Gateway = "fe80::1"; }
       ];
       # Linode anti-spoofing drops packets from unknown source addresses,
       # so disable IPv6 privacy extensions and accept RAs even with forwarding.

--- a/hosts/piplup.nix
+++ b/hosts/piplup.nix
@@ -29,8 +29,8 @@
         "2600:3c01::f03c:94ff:fe23:6ecc/64"
       ];
       routes = [
-        { routeConfig.Gateway = "50.116.4.1"; }
-        { routeConfig.Gateway = "fe80::1"; }
+        { Gateway = "50.116.4.1"; }
+        { Gateway = "fe80::1"; }
       ];
       # Linode anti-spoofing drops packets from unknown source addresses,
       # so disable IPv6 privacy extensions and accept RAs even with forwarding.

--- a/hosts/turtwig.nix
+++ b/hosts/turtwig.nix
@@ -29,8 +29,8 @@
         "2600:3c01::f03c:94ff:fe23:6ecb/64"
       ];
       routes = [
-        { routeConfig.Gateway = "50.116.4.1"; }
-        { routeConfig.Gateway = "fe80::1"; }
+        { Gateway = "50.116.4.1"; }
+        { Gateway = "fe80::1"; }
       ];
       # Linode anti-spoofing drops packets from unknown source addresses,
       # so disable IPv6 privacy extensions and accept RAs even with forwarding.

--- a/modules/poketwo/kubernetes.nix
+++ b/modules/poketwo/kubernetes.nix
@@ -50,7 +50,7 @@ in
     # while allowing the rest of the system to track nixos-unstable.
     nixpkgs.overlays = [
       (final: prev:
-        let k8sPkgs = import inputs.nixpkgs-k8s { inherit (prev) system; config = { allowUnfree = true; }; };
+        let k8sPkgs = import inputs.nixpkgs-k8s { inherit (prev.stdenv.hostPlatform) system; config = { allowUnfree = true; }; };
         in {
           kubernetes = k8sPkgs.kubernetes;
           cri-o = k8sPkgs.cri-o;
@@ -114,7 +114,7 @@ in
 
       serviceConfig = {
         Restart = "always";
-        StartLimitInterval = 0;
+        StartLimitIntervalSec = 0;
         RestartSec = 10;
 
         # Provided by kubeadm drop-in file

--- a/modules/poketwo/network.nix
+++ b/modules/poketwo/network.nix
@@ -56,8 +56,8 @@ in
             "2606:c2c0:5::1:${toString cfg.lastOctet}/32"
           ];
           routes = [
-            { routeConfig.Gateway = "23.135.200.1"; }
-            { routeConfig.Gateway = "2606:c2c0::1"; }
+            { Gateway = "23.135.200.1"; }
+            { Gateway = "2606:c2c0::1"; }
           ];
           domains = [ ];
           linkConfig.RequiredForOnline = "routable";


### PR DESCRIPTION
## Summary

Fixes three categories of evaluation warnings emitted during `nix build` / `disko-install`:

1. **`routeConfig` deprecated** — `routeConfig.Gateway` → `Gateway` in `systemd.network.networks.*.routes` (4 files: `network.nix`, `chimchar.nix`, `piplup.nix`, `turtwig.nix`)
2. **`StartLimitInterval` deprecated** — `StartLimitInterval` → `StartLimitIntervalSec` in `kubernetes.nix` kubelet service
3. **`system` deprecated** — `inherit (prev) system` → `inherit (prev.stdenv.hostPlatform) system` in the nixpkgs-k8s overlay in `kubernetes.nix`

All changes are mechanical renames following the documented deprecation migration paths. No behavioral changes intended.

## Review & Testing Checklist for Human

- [ ] **Verify network routing after deploy** — The `routeConfig` change affects routing on all Isogram servers (via `network.nix`) and all three Linode servers (chimchar, piplup, turtwig). After deploying, confirm servers are still reachable and routes are correct with `networkctl status` and `ip route show`.
- [ ] **Verify kubelet still starts on k8s nodes** — The `StartLimitIntervalSec` rename should be functionally identical, but confirm with `systemctl status kubelet` after deploy.

### Notes
- The `routeConfig` wrapper has been deprecated since nixpkgs 24.05. The generated systemd-networkd `.network` files should be byte-identical before and after this change.
- The `system` deprecation warning originated from the k8s overlay added in a previous PR. `prev.stdenv.hostPlatform.system` is the canonical way to access the system string in overlays.

Link to Devin session: https://app.devin.ai/sessions/506280557c4d4e6ead5d16b127d5bef5
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
