### PR TITLE
fix: pin os-shell init container image to latest tag

### DIFF
--- a/kubernetes/poketwo/mongodb.nix
+++ b/kubernetes/poketwo/mongodb.nix
@@ -90,6 +90,7 @@ in
         volumePermissions = {
           enabled = true;
           image.repository = "bitnamilegacy/os-shell";
+          image.tag = "latest";
         };
         metrics = {
           enabled = true;


### PR DESCRIPTION
The bitnami/os-shell:12-debian-12-r23 tag has been removed from Docker Hub, causing mongodb-1 to be stuck in Init:ImagePullBackOff. Pin to the `latest` tag which is the only human-readable tag still available.

Generated with [Devin](https://cli.devin.ai/docs)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
