### PR TITLE
feat: deploy Tailscale K8s operator as in-cluster subnet router, fix DNS

### DIFF
--- a/kubernetes/core/cilium.nix
+++ b/kubernetes/core/cilium.nix
@@ -64,7 +64,10 @@
 
     resources."cilium.io/v2".CiliumClusterwideNetworkPolicy.deny-external.spec = {
       endpointSelector = { };
-      ingress = [{ fromEntities = [ "cluster" ]; }];
+      ingress = [
+        { fromEntities = [ "cluster" ]; }
+        { fromCIDR = [ "fd7a:115c:a1e0::/48" ]; } # Tailscale IPv6 range
+      ];
       egress = [{ toEntities = [ "all" ]; }];
     };
   };

--- a/kubernetes/core/cilium.nix
+++ b/kubernetes/core/cilium.nix
@@ -27,6 +27,14 @@
         loadBalancer.mode = "hybrid";
         endpointRoutes.enabled = true;
 
+        # Bypass socket LB in pod namespaces so Tailscale operator's
+        # netfilter-based firewall rules work correctly.
+        # https://tailscale.com/kb/1236/kubernetes-operator#cilium-in-kube-proxy-replacement-mode
+        socketLB = {
+          enabled = true;
+          hostNamespaceOnly = true;
+        };
+
         # We use globally routable addresses for IPv6, so no NAT is needed.
         # We're running IPv6-only, but Discord still needs IPv4...
         # For now, that is accomplished with NAT64 on the host. :)

--- a/kubernetes/core/cilium.nix
+++ b/kubernetes/core/cilium.nix
@@ -64,10 +64,7 @@
 
     resources."cilium.io/v2".CiliumClusterwideNetworkPolicy.deny-external.spec = {
       endpointSelector = { };
-      ingress = [
-        { fromEntities = [ "cluster" ]; }
-        { fromCIDR = [ "fd7a:115c:a1e0::/48" ]; } # Tailscale IPv6 range
-      ];
+      ingress = [{ fromEntities = [ "cluster" ]; }];
       egress = [{ toEntities = [ "all" ]; }];
     };
   };

--- a/kubernetes/core/tailscale-operator.nix
+++ b/kubernetes/core/tailscale-operator.nix
@@ -1,0 +1,39 @@
+{ transpire, ... }:
+
+{
+  namespaces.tailscale = {
+    helmReleases.tailscale-operator = {
+      chart = transpire.fetchFromHelm {
+        repo = "https://pkgs.tailscale.com/helmcharts";
+        name = "tailscale-operator";
+        version = "1.96.5";
+        sha256 = "lVmVHGtWmvPbRY42IuiPEn6y4RSvkGu0E80NffoBvRA=";
+      };
+
+      values = {
+        operatorConfig = {
+          defaultTags = [ "tag:k8s-operator" ];
+          hostname = "hfym-ds-operator";
+        };
+      };
+
+      includeCRDs = true;
+    };
+
+    # OAuth credentials for the Tailscale operator (managed via Vault)
+    resources.v1.Secret.operator-oauth = {
+      type = "Opaque";
+      stringData = {
+        client_id = "";
+        client_secret = "";
+      };
+    };
+
+    # Subnet router for Kubernetes service CIDR
+    resources."tailscale.com/v1alpha1".Connector.k8s-subnet-router.spec = {
+      subnetRouter = {
+        advertiseRoutes = [ "2606:c2c0:5:1:2::/112" ];
+      };
+    };
+  };
+}

--- a/kubernetes/core/tailscale-operator.nix
+++ b/kubernetes/core/tailscale-operator.nix
@@ -12,8 +12,11 @@
 
       values = {
         operatorConfig = {
-          defaultTags = [ "tag:k8s-operator" ];
+          defaultTags = [ "tag:hfym-ds-operator" ];
           hostname = "hfym-ds-operator";
+        };
+        proxyConfig = {
+          defaultTags = [ "tag:hfym-ds" ];
         };
       };
 

--- a/modules/poketwo/tailscale.nix
+++ b/modules/poketwo/tailscale.nix
@@ -6,6 +6,12 @@ in
 {
   options.poketwo.tailscale = {
     enable = lib.mkEnableOption "Enable Tailscale configuration";
+
+    advertiseRoutes = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "List of CIDRs to advertise as subnet routes via Tailscale";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -21,12 +27,14 @@ in
       openFirewall = true;
       authKeyFile = config.age.secrets.tailscale-auth-key.path;
       extraUpFlags = [
-        "--accept-dns"
+        "--accept-dns=false"
         "--accept-routes"
         "--advertise-connector"
         "--advertise-exit-node"
         "--ssh"
         "--stateful-filtering"
+      ] ++ lib.optionals (cfg.advertiseRoutes != [ ]) [
+        "--advertise-routes=${lib.concatStringsSep "," cfg.advertiseRoutes}"
       ];
     };
   };

--- a/modules/poketwo/tailscale.nix
+++ b/modules/poketwo/tailscale.nix
@@ -6,12 +6,6 @@ in
 {
   options.poketwo.tailscale = {
     enable = lib.mkEnableOption "Enable Tailscale configuration";
-
-    advertiseRoutes = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      description = "List of CIDRs to advertise as subnet routes via Tailscale";
-    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -33,8 +27,6 @@ in
         "--advertise-exit-node"
         "--ssh"
         "--stateful-filtering"
-      ] ++ lib.optionals (cfg.advertiseRoutes != [ ]) [
-        "--advertise-routes=${lib.concatStringsSep "," cfg.advertiseRoutes}"
       ];
     };
   };

--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -22,6 +22,7 @@
     nat64.enable = lib.mkDefault true;
     shell.enable = lib.mkDefault true;
     tailscale.enable = lib.mkDefault true;
+    tailscale.advertiseRoutes = lib.mkDefault [ "2606:c2c0:5:1:2::/112" ];
   };
 
   boot = {

--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -22,7 +22,6 @@
     nat64.enable = lib.mkDefault true;
     shell.enable = lib.mkDefault true;
     tailscale.enable = lib.mkDefault true;
-    tailscale.advertiseRoutes = lib.mkDefault [ "2606:c2c0:5:1:2::/112" ];
   };
 
   boot = {


### PR DESCRIPTION
## Summary

Three changes to enable accessing all Kubernetes services through Tailscale:

1. **Fix DNS breakage** (`modules/poketwo/tailscale.nix`): Changed `--accept-dns` to `--accept-dns=false`. Tailscale's MagicDNS resolver (`100.100.100.100`) is IPv4-only — on the IPv6-only cluster, CoreDNS pods (with `dnsPolicy: Default`) inherit this as their upstream and can't reach it, breaking all in-cluster DNS. With `--accept-dns=false`, nodes keep using Cloudflare nameservers which CoreDNS can reach over IPv6.

2. **Deploy Tailscale K8s Operator** (`kubernetes/core/tailscale-operator.nix`): Deploys the [Tailscale Kubernetes Operator](https://tailscale.com/docs/features/kubernetes-operator) (Helm chart v1.96.5) with a `Connector` CRD that advertises the Kubernetes service CIDR (`2606:c2c0:5:1:2::/112`) as a subnet route. The subnet router runs as a pod inside the cluster, so traffic naturally passes the `deny-external` Cilium policy — no CIDR exception needed. OAuth credentials are managed via Vault at `hfym-ds/tailscale/operator-oauth`. Tags match the previous operator setup (`tag:hfym-ds-operator`, `tag:hfym-ds`).

3. **Cilium socketLB bypass** (`kubernetes/core/cilium.nix`): Adds `socketLB.hostNamespaceOnly = true` per [Tailscale's docs](https://tailscale.com/kb/1236/kubernetes-operator#cilium-in-kube-proxy-replacement-mode) — required because Cilium's socket LB in pod namespaces bypasses netfilter hooks that Tailscale's firewall rules attach to. This was the [previous blocker](https://github.com/poketwo/nix/commit/1072602) for the operator: [cilium/cilium#26733](https://github.com/cilium/cilium/issues/26733) (IPv6 service loopback) is now fixed in Cilium 1.17+ via [cilium/cilium#39594](https://github.com/cilium/cilium/pull/39594), and we run 1.18.8.

Note: Chart v1.96.5 also includes the fix for [tailscale/tailscale#15762](https://github.com/tailscale/tailscale/issues/15762) which previously broke Connector deployment on IPv6-only clusters.

## Review & Testing Checklist for Human

- [ ] Create a Tailscale OAuth client at [Settings → OAuth clients](https://login.tailscale.com/admin/settings/oauth) and push credentials to Vault at `hfym-ds/tailscale/operator-oauth` (keys: `client_id`, `client_secret`)
- [ ] Ensure tailnet policy file has `tag:hfym-ds-operator` and `tag:hfym-ds` tags, with `tag:hfym-ds-operator` as owner of `tag:hfym-ds`
- [ ] After deploying NixOS changes, verify DNS still works inside pods (`kubectl exec ... -- nslookup google.com`)
- [ ] After ArgoCD syncs, verify the Connector pod is running and the subnet route appears in the [Tailscale admin console](https://login.tailscale.com/admin/machines) — approve the route
- [ ] From a Tailscale-connected client, test accessing a ClusterIP service (e.g. `curl -6 http://[service-ip]:port`)

### Notes

- The `--accept-dns=false` change needs to be deployed to all nodes via `deploy-rs` or `nixos-rebuild`
- The Kubernetes manifests will be rendered by CI and deployed via ArgoCD from the `cluster` branch
- The `socketLB.hostNamespaceOnly` change was previously used in [commit `399152c`](https://github.com/poketwo/nix/commit/399152c) but removed along with the operator in [commit `1072602`](https://github.com/poketwo/nix/commit/1072602) due to [cilium/cilium#26733](https://github.com/cilium/cilium/issues/26733) — now resolved

Link to Devin session: https://app.devin.ai/sessions/cb0a30d2b3c34b95a6a4b8ebb3000255
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
