### PR TITLE
fix: update tailscale-operator helm chart hash

### DIFF
--- a/kubernetes/core/tailscale-operator.nix
+++ b/kubernetes/core/tailscale-operator.nix
@@ -7,7 +7,7 @@
         repo = "https://pkgs.tailscale.com/helmcharts";
         name = "tailscale-operator";
         version = "1.96.5";
-        sha256 = "lVmVHGtWmvPbRY42IuiPEn6y4RSvkGu0E80NffoBvRA=";
+        sha256 = "Dh/fRXdA9z+TMfg7rzfKhKt5cRh6cDYPotP4hXvEpls=";
       };
 
       values = {


### PR DESCRIPTION
## Summary

The Tailscale operator Helm chart v1.96.5 was republished upstream, causing a sha256 hash mismatch in the Nix build. Updates the hash from `lVmVHGtWmvPbRY42IuiPEn6y4RSvkGu0E80NffoBvRA=` to `Dh/fRXdA9z+TMfg7rzfKhKt5cRh6cDYPotP4hXvEpls=`.

## Review & Testing Checklist for Human

- [ ] Verify the `nix build .#kubernetes` succeeds locally

### Notes

Hash was obtained from the CI error output: https://github.com/poketwo/nix/actions/runs/24294109398/job/70936060686

Link to Devin session: https://app.devin.ai/sessions/cb0a30d2b3c34b95a6a4b8ebb3000255
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
