### PR TITLE
fix: proxyConfig.defaultTags type, add K8s CI check, cache + rename workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,6 +36,24 @@ jobs:
           hosts=$(nix eval --json .#nixosConfigurations --apply 'x: builtins.attrNames x')
           echo "hosts=$hosts" >> "$GITHUB_OUTPUT"
 
+  kubernetes:
+    runs-on: ubuntu-latest
+    needs: check-flake
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-kubernetes-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: |
+            nix-kubernetes-
+          gc-max-store-size-linux: 4000000000
+      - name: Build Kubernetes manifests
+        run: nix build .#kubernetes
+
   build:
     runs-on: ubuntu-latest
     needs: [check-flake, hosts]

--- a/.github/workflows/publish-kubernetes.yaml
+++ b/.github/workflows/publish-kubernetes.yaml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Publish Kubernetes Manifests
 
 on:
   push:
@@ -22,6 +22,13 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@v3
       - name: Check Nix flake inputs
         uses: DeterminateSystems/flake-checker-action@v10
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-kubernetes-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: |
+            nix-kubernetes-
+          gc-max-store-size-linux: 4000000000
 
       - name: Build Kubernetes cluster
         run: nix build .#kubernetes
@@ -32,7 +39,7 @@ jobs:
           name: cluster
           path: result/
 
-  deploy:
+  publish:
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/kubernetes/core/tailscale-operator.nix
+++ b/kubernetes/core/tailscale-operator.nix
@@ -16,7 +16,9 @@
           hostname = "hfym-ds-operator";
         };
         proxyConfig = {
-          defaultTags = [ "tag:hfym-ds" ];
+          # Must be a string, not a list — chart template doesn't join it
+          # https://github.com/tailscale/tailscale/issues/16773
+          defaultTags = "tag:hfym-ds";
         };
       };
 


### PR DESCRIPTION
## Summary

Three changes:

1. **Fix `proxyConfig.defaultTags` type**: The Tailscale Helm chart template doesn't join `proxyConfig.defaultTags` with commas like it does for `operatorConfig.defaultTags` ([tailscale/tailscale#16773](https://github.com/tailscale/tailscale/issues/16773)). Changed from list `[ "tag:hfym-ds" ]` to string `"tag:hfym-ds"` to fix the build error: `PROXY_TAGS.value is not of type 'null or string'`.

2. **Add Kubernetes manifest build to PR CI**: Added a `kubernetes` job to `build.yaml` that runs `nix build .#kubernetes` on PRs, so K8s manifest build failures are caught before merging (would have caught the hash mismatch and this type error).

3. **CI improvements**:
   - Added Nix store cache (`nix-community/cache-nix-action`) to both the PR K8s build and the publish workflow, keyed on `flake.lock` hash
   - Renamed `build-and-deploy.yaml` → `publish-kubernetes.yaml` / "Publish Kubernetes Manifests" (ArgoCD deploys, CI just publishes)
   - Renamed `deploy` job → `publish`

## Review & Testing Checklist for Human
- [ ] Verify the `kubernetes` CI job passes on this PR (it's the first run, so it validates itself)
- [ ] After merging, verify the "Publish Kubernetes Manifests" workflow triggers correctly on push to main
- [ ] Verify subsequent CI runs are faster due to Nix store caching

### Notes
- The Nix store cache key is `nix-kubernetes-${{ hashFiles('flake.lock') }}` — it will be shared between PR checks and the publish workflow since the key is the same
- The `kubernetes` PR job only depends on `check-flake`, not `hosts`, so it starts earlier than host builds

Link to Devin session: https://app.devin.ai/sessions/cb0a30d2b3c34b95a6a4b8ebb3000255
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
