### PR TITLE
ci: add K8s manifest build to PR checks, cache Nix store, rename workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,6 +36,24 @@ jobs:
           hosts=$(nix eval --json .#nixosConfigurations --apply 'x: builtins.attrNames x')
           echo "hosts=$hosts" >> "$GITHUB_OUTPUT"
 
+  kubernetes:
+    runs-on: ubuntu-latest
+    needs: check-flake
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-kubernetes-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: |
+            nix-kubernetes-
+          gc-max-store-size-linux: 4000000000
+      - name: Build Kubernetes manifests
+        run: nix build .#kubernetes
+
   build:
     runs-on: ubuntu-latest
     needs: [check-flake, hosts]

--- a/.github/workflows/publish-kubernetes.yaml
+++ b/.github/workflows/publish-kubernetes.yaml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Publish Kubernetes Manifests
 
 on:
   push:
@@ -22,6 +22,13 @@ jobs:
         uses: DeterminateSystems/determinate-nix-action@v3
       - name: Check Nix flake inputs
         uses: DeterminateSystems/flake-checker-action@v10
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-kubernetes-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: |
+            nix-kubernetes-
+          gc-max-store-size-linux: 4000000000
 
       - name: Build Kubernetes cluster
         run: nix build .#kubernetes
@@ -32,7 +39,7 @@ jobs:
           name: cluster
           path: result/
 
-  deploy:
+  publish:
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
## Summary

CI improvements for the Kubernetes manifest build:

1. **Add K8s manifest build to PR CI**: New `kubernetes` job in `build.yaml` runs `nix build .#kubernetes` on PRs, catching manifest build failures before merging (would have caught the hash mismatch and type errors from the Tailscale operator PRs).

2. **Add Nix store cache**: Both the PR build and publish workflow now use `nix-community/cache-nix-action` keyed on `flake.lock`, so subsequent builds only fetch/build what changed.

3. **Rename workflow**: `build-and-deploy.yaml` → `publish-kubernetes.yaml` / "Publish Kubernetes Manifests" — ArgoCD deploys, CI just publishes to the `cluster` branch.

## Review & Testing Checklist for Human
- [ ] After merging, verify the "Publish Kubernetes Manifests" workflow triggers correctly on push to main
- [ ] Verify the `kubernetes` job appears in PR CI checks
- [ ] On a subsequent run, verify cache hit speeds up the build

### Notes
- The `kubernetes` PR job only depends on `check-flake`, not `hosts`, so it starts in parallel with host builds
- Cache key `nix-kubernetes-${{ hashFiles('flake.lock') }}` is shared between PR and publish workflows

Link to Devin session: https://app.devin.ai/sessions/cb0a30d2b3c34b95a6a4b8ebb3000255
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
