### PR TITLE
fix: pass proxyConfig.defaultTags as string, not list

### DIFF
--- a/kubernetes/core/tailscale-operator.nix
+++ b/kubernetes/core/tailscale-operator.nix
@@ -16,7 +16,9 @@
           hostname = "hfym-ds-operator";
         };
         proxyConfig = {
-          defaultTags = [ "tag:hfym-ds" ];
+          # Must be a string, not a list — chart template doesn't join it
+          # https://github.com/tailscale/tailscale/issues/16773
+          defaultTags = "tag:hfym-ds";
         };
       };
 


### PR DESCRIPTION
## Summary

Fix the K8s manifest build failure: `proxyConfig.defaultTags` must be a string, not a list. The Tailscale Helm chart template doesn't join `proxyConfig.defaultTags` with commas like it does for `operatorConfig.defaultTags` ([tailscale/tailscale#16773](https://github.com/tailscale/tailscale/issues/16773)).

Error was: `A definition for option namespaces.tailscale.resources."apps/v1".Deployment.operator.spec.template.spec.containers.operator.env.PROXY_TAGS.value is not of type 'null or string'`

## Review & Testing Checklist for Human
- [ ] Verify CI passes (K8s manifest builds successfully)

### Notes
- This is the fix half of #16, split into its own PR. The CI improvements are in a separate PR.

Link to Devin session: https://app.devin.ai/sessions/cb0a30d2b3c34b95a6a4b8ebb3000255
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
