### PR TITLE
ci: separate NixOS and Kubernetes workflows, add K8s PR checks + cache

### DIFF
--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -1,12 +1,13 @@
-name: Build and Deploy
+name: Build Kubernetes Manifests
 
 on:
+  pull_request:
   push:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: kubernetes-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -20,19 +21,24 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@v3
-      - name: Check Nix flake inputs
-        uses: DeterminateSystems/flake-checker-action@v10
-
-      - name: Build Kubernetes cluster
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-kubernetes-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: |
+            nix-kubernetes-
+          gc-max-store-size-linux: 4000000000
+      - name: Build Kubernetes manifests
         run: nix build .#kubernetes
-
       - name: Upload cluster artifact
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: cluster
           path: result/
 
-  deploy:
+  publish:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/nixos.yaml
+++ b/.github/workflows/nixos.yaml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: build-${{ github.ref }}
+  group: nixos-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Separates CI into two independent workflows:

- **`nixos.yaml`** (renamed from `build.yaml`) — "Build NixOS Hosts". Flake check + matrix build of all NixOS host configs. PR + push to main.

- **`kubernetes.yaml`** (renamed from `build-and-deploy.yaml`) — "Build Kubernetes Manifests". Builds on PRs (catches manifest errors before merging), builds + publishes to `cluster` branch on push to main. Includes Nix store cache. No duplicate K8s builds on push to main.

Key changes:
- K8s manifests are now validated on PRs (would have caught the recent hash mismatch and `PROXY_TAGS` type error)
- Nix store cache added to K8s builds
- `publish` job and artifact upload gated to main only (`if: github.ref == 'refs/heads/main'`)
- Concurrency groups updated to `nixos-*` and `kubernetes-*`

## Review & Testing Checklist for Human
- [ ] Verify the `build` job in "Build Kubernetes Manifests" passes on this PR
- [ ] After merging, verify the `publish` job triggers and pushes to `cluster` branch

### Notes
- Supersedes #16 and #17

Link to Devin session: https://app.devin.ai/sessions/cb0a30d2b3c34b95a6a4b8ebb3000255
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
