### PR TITLE
feat: allow ingress from tailscale namespace for subnet router access

### DIFF
--- a/kubernetes/core/cilium.nix
+++ b/kubernetes/core/cilium.nix
@@ -75,5 +75,18 @@
       ingress = [{ fromEntities = [ "cluster" ]; }];
       egress = [{ toEntities = [ "all" ]; }];
     };
+
+    # Allow ingress from the Tailscale subnet router so traffic routed
+    # through the tailnet can reach cluster services.
+    resources."cilium.io/v2".CiliumClusterwideNetworkPolicy.allow-tailscale.spec = {
+      endpointSelector = { };
+      ingress = [{
+        fromEndpoints = [{
+          matchLabels = {
+            "k8s:io.kubernetes.pod.namespace" = "tailscale";
+          };
+        }];
+      }];
+    };
   };
 }


### PR DESCRIPTION
## Summary

Adds a `CiliumClusterwideNetworkPolicy` (`allow-tailscale`) that permits ingress from pods in the `tailscale` namespace to all cluster endpoints.

Currently, the `deny-external` policy only allows ingress from the `cluster` entity. Traffic routed through the Tailscale subnet router arrives at cluster services with the Connector pod as the source, but gets rejected because the forwarded traffic doesn't match the `cluster` entity. This policy allows traffic originating from the `tailscale` namespace (where the Connector/subnet router pod runs) to reach cluster services.

This is secure because:
- Only devices on the tailnet can send traffic through the Connector (gated by Tailscale ACLs)
- The Connector pod is the only ingress path — traffic arrives over an encrypted WireGuard tunnel
- The policy is scoped to the `tailscale` namespace, which is controlled by the cluster admin

## Review & Testing Checklist for Human
- [ ] After merging and ArgoCD sync, verify you can connect to a cluster service from your laptop via Tailscale: `curl -k https://argocd-server.argocd.svc.ds.hfym.co` (or `.svc.cluster.local`)
- [ ] Verify the `deny-external` policy still blocks traffic from outside the cluster (non-tailscale sources)

### Notes
- Fixes the "connection reset by peer" error when accessing cluster services through the Tailscale subnet router
- The `deny-external` policy remains unchanged — this is an additive policy

Link to Devin session: https://app.devin.ai/sessions/cb0a30d2b3c34b95a6a4b8ebb3000255
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
