### PR TITLE
feat: enable ServerSideApply for all ArgoCD apps

### DIFF
--- a/applicationset.yaml
+++ b/applicationset.yaml
@@ -27,6 +27,7 @@ spec:
         automated: {}
         syncOptions:
           - CreateNamespace=true
+          - ServerSideApply=true
   syncPolicy:
     applicationsSync: create-update
   ignoreApplicationDifferences:


### PR DESCRIPTION
## Summary

Enables `ServerSideApply=true` in the ArgoCD ApplicationSet sync options for all apps. This switches from client-side apply to server-side apply, which avoids storing the full resource manifest in `kubectl.kubernetes.io/last-applied-configuration` annotations.

Fixes the sync failure for `cilium-dashboard` ConfigMap where the annotation exceeded the 262KB Kubernetes annotation size limit:

```
ConfigMap "cilium-dashboard" is invalid: metadata.annotations: Too long: must have at most 262144 bytes
```

## Review & Testing Checklist for Human
- [ ] After merging, apply the ApplicationSet manually: `kubectl apply -f applicationset.yaml -n argocd`
- [ ] Verify ArgoCD re-syncs the Cilium app successfully (the `cilium-dashboard` ConfigMap should apply without the annotation size error)
- [ ] Spot-check a few other apps to make sure SSA doesn't cause unexpected conflicts

### Notes
- The ApplicationSet is not managed by ArgoCD itself — it needs to be applied manually with `kubectl apply`
- SSA is the recommended approach going forward; client-side apply is considered legacy
- No behavioral change for normal resources — SSA only differs for conflict detection (which is fine since ArgoCD is the sole manager)

Link to Devin session: https://app.devin.ai/sessions/cb0a30d2b3c34b95a6a4b8ebb3000255
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
