### PR TITLE
fix: use fromCIDRSet for Tailscale ingress policy

### DIFF
--- a/kubernetes/core/cilium.nix
+++ b/kubernetes/core/cilium.nix
@@ -76,15 +76,15 @@
       egress = [{ toEntities = [ "all" ]; }];
     };
 
-    # Allow ingress from the Tailscale subnet router so traffic routed
-    # through the tailnet can reach cluster services.
+    # Allow ingress from Tailscale IPs so traffic routed through the
+    # tailnet can reach cluster services. The Connector forwards packets
+    # without SNAT, so the source IP is the client's Tailscale address
+    # (fd7a:115c:a1e0::/48), not the Connector pod's IP.
     resources."cilium.io/v2".CiliumClusterwideNetworkPolicy.allow-tailscale.spec = {
       endpointSelector = { };
       ingress = [{
-        fromEndpoints = [{
-          matchLabels = {
-            "k8s:io.kubernetes.pod.namespace" = "tailscale";
-          };
+        fromCIDRSet = [{
+          cidr = "fd7a:115c:a1e0::/48";
         }];
       }];
     };


### PR DESCRIPTION
## Summary

Fixes the `allow-tailscale` CiliumClusterwideNetworkPolicy to use `fromCIDRSet` instead of `fromEndpoints`.

The Tailscale Connector (subnet router) forwards packets without SNAT, so the source IP arriving at destination pods is the client's Tailscale address (`fd7a:115c:a1e0::/48`), not the Connector pod's cluster IP. Since `fromEndpoints` requires Cilium to identify the source as a known pod (by namespace label), it can't match non-pod Tailscale IPs — causing all traffic except to services with their own allow policies (like `ag-postgres-rw`) to be dropped/reset.

## Review & Testing Checklist for Human
- [ ] After merging + ArgoCD sync, test connectivity: `curl -k https://argocd-server.argocd.svc.ds.hfym.co`
- [ ] Verify other services are also reachable (e.g. Grafana, Hubble UI)
- [ ] Confirm the `fd7a:115c:a1e0::/48` CIDR is appropriate — this allows all Tailscale IPv6 addresses in your tailnet. Access control is enforced by Tailscale ACLs.

### Notes
- The previous `fromEndpoints` policy (matching `k8s:io.kubernetes.pod.namespace = tailscale`) was ineffective because the Connector doesn't SNAT — Cilium never saw traffic from a pod in the tailscale namespace
- `100.64.0.0/10` (Tailscale IPv4 CGNAT) is not included since the cluster is IPv6-only

Link to Devin session: https://app.devin.ai/sessions/cb0a30d2b3c34b95a6a4b8ebb3000255
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
