### PR TITLE
fix: set externalTrafficPolicy to Cluster for mongodb external services

### DIFF
--- a/kubernetes/poketwo/mongodb.nix
+++ b/kubernetes/poketwo/mongodb.nix
@@ -75,6 +75,7 @@ in
               { "external-dns.alpha.kubernetes.io/hostname" = "mongodb-1-external.poketwo.ds.hfym.co"; }
             ];
             type = "LoadBalancer";
+            externalTrafficPolicy = "Cluster";
             ports.mongodb = 27017;
           };
         };


### PR DESCRIPTION
## Summary

Sets `externalTrafficPolicy = "Cluster"` on the mongodb external access services to fix the hairpin routing failure causing mongodb-1 to be stuck at 1/2 Ready.

**Root cause:** The recent `socketLB.hostNamespaceOnly = true` change in Cilium (#14, for Tailscale operator support) disabled socket-level LB in pod namespaces. Previously, Cilium intercepted mongodb's self-connections at the socket layer and translated the LB VIP directly to the pod IP — bypassing the LoadBalancer path entirely. Now, traffic goes through the netfilter/MetalLB path where `externalTrafficPolicy: Local` (the bitnami chart default) causes a hairpin routing failure: the pod can't reach its own LB VIP from the same node because the DNAT reply bypasses reverse NAT when src == dst.

Switching to `Cluster` avoids the hairpin by allowing SNAT-based forwarding through any node. Source IP preservation is not needed for MongoDB (password-based auth, not IP-based).

## Review & Testing Checklist for Human

- [ ] After ArgoCD syncs, verify mongodb-1 becomes 2/2 Ready: `kubectl get pod mongodb-1 -n poketwo`
- [ ] Verify replica set health from the primary: `rs.status()` should show mongodb-1 as SECONDARY with `health: 1`
- [ ] Confirm external connectivity still works: `mongosh mongodb-1-external.poketwo.ds.hfym.co:27017` from outside the cluster

### Notes

- This is a one-line change to the bitnami mongodb Helm values — adds `externalTrafficPolicy = "Cluster"` under `externalAccess.service`.
- The mongodb-1 pod may need a restart or the replica set member may need to be re-added after the service policy change takes effect.
- The same hairpin issue could theoretically affect mongodb-0 if it ever restarts on vaporeon, since the same `externalTrafficPolicy: Local` default applied to both external services.

Link to Devin session: https://app.devin.ai/sessions/283a67fd6ae044cea8914537a486d995
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
