### PR TITLE
feat: configure SSO for Grafana via Keycloak OIDC

### DIFF
--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -30,6 +30,26 @@
           ];
         };
 
+        "grafana.ini" = {
+          server.root_url = "https://grafana.hfym.co";
+          "auth.generic_oauth" = {
+            enabled = true;
+            name = "Pokétwo";
+            allow_sign_up = true;
+            auto_login = true;
+            client_id = "grafana.hfym.co";
+            scopes = "openid email profile";
+            auth_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/auth";
+            token_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/token";
+            api_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/userinfo";
+          };
+        };
+
+        envFromSecrets = [{
+          name = "grafana-oidc";
+          optional = false;
+        }];
+
         ingress = {
           enabled = true;
           annotations."cert-manager.io/cluster-issuer" = "letsencrypt";
@@ -47,6 +67,13 @@
       stringData = {
         admin-user = "admin";
         admin-password = "";
+      };
+    };
+
+    resources.v1.Secret.grafana-oidc = {
+      type = "Opaque";
+      stringData = {
+        GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET = "";
       };
     };
   };

--- a/kubernetes/poketwo/keycloak.nix
+++ b/kubernetes/poketwo/keycloak.nix
@@ -54,6 +54,15 @@ let
         protocol = "openid-connect";
         enabled = true;
       }
+      {
+        clientId = "grafana.hfym.co";
+        name = "Grafana";
+        redirectUris = [ "https://grafana.hfym.co/login/generic_oauth" ];
+        clientAuthenticatorType = "client-secret";
+        publicClient = false;
+        protocol = "openid-connect";
+        enabled = true;
+      }
     ];
 
     # Override this to turn creating users off


### PR DESCRIPTION
## Summary

Configures Grafana to authenticate via Keycloak OIDC, matching the existing SSO pattern used by Outline.

**Changes:**

- **`kubernetes/poketwo/keycloak.nix`**: Added a `grafana.hfym.co` OIDC client to the Keycloak realm config with redirect URI pointing to Grafana's OAuth callback.
- **`kubernetes/monitoring/grafana.nix`**:
  - Added `grafana.ini` configuration for `auth.generic_oauth` pointing to the Keycloak `poketwo` realm endpoints.
  - Set `auto_login = true` to redirect users directly to Keycloak.
  - Added `envFromSecrets` referencing a `grafana-oidc` secret to inject `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET`.
  - Added a `grafana-oidc` Vault-managed secret (transformed to `VaultStaticSecret` automatically).

## Review & Testing Checklist for Human

- [ ] **Create the Vault secret** at `hfym-ds/grafana/grafana-oidc` with key `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET` — grab the client secret from Keycloak admin after the `grafana.hfym.co` client is created.
- [ ] **Verify the Keycloak client** appears in the admin console under the `poketwo` realm after ArgoCD syncs.
- [ ] **Test SSO flow**: visit `https://grafana.hfym.co` → should redirect to Keycloak → log in → land back in Grafana authenticated.
- [ ] **Check role assignment** — OAuth users default to `Viewer`. Adjust `role_attribute_path` if you want different mapping.

### Notes

- The OIDC client secret must be in Vault before the Grafana pod starts (`optional = false` on `envFromSecrets`).
- `auto_login = true` bypasses the Grafana login page. To reach local admin login: `https://grafana.hfym.co/login?disableAutoLogin`.

Link to Devin session: https://app.devin.ai/sessions/4080ff89c01d42b69acd57b04293525e
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
