### PR TITLE
feat: set SSO users to Editor role in Grafana

### DIFF
--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -42,6 +42,7 @@
             auth_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/auth";
             token_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/token";
             api_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/userinfo";
+            role_attribute_path = "'Editor'";
           };
         };
 


### PR DESCRIPTION
## Summary

Sets all Grafana SSO users to the **Editor** role via `role_attribute_path`. Follow-up to #24.

## Review & Testing Checklist for Human

- [ ] Log in via SSO and confirm your Grafana role is `Editor` (check under your profile or try creating a dashboard).

### Notes

- Uses JMESPath literal `'Editor'` so all OAuth users unconditionally get the Editor role.
- The local `admin` account is unaffected.

Link to Devin session: https://app.devin.ai/sessions/4080ff89c01d42b69acd57b04293525e
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
