### PR TITLE
chore: update nixpkgs to fix CVE-2026-31431

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -127,11 +127,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774106199,
-        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
Update the `nixpkgs` flake input from `6c9a78c` (2026-03-21) to `1c3fe55` (2026-04-25, nixos-unstable).

This bumps the default kernel from **6.18.19 → 6.18.24**, which includes the fix for [CVE-2026-31431](https://nvd.nist.gov/vuln/detail/CVE-2026-31431) — a local privilege escalation vulnerability in `crypto/algif_aead` (CVSS 7.8 HIGH). The fix was backported to stable kernel 6.18.22.

## Review & Testing Checklist for Human
- [ ] Verify the new nixpkgs revision resolves correctly by running `nix flake metadata` or `nix build .#kubernetes` locally
- [ ] After merging, deploy to at least one control plane node first (e.g. `deploy .#turtwig`) and verify it boots with the new kernel (`uname -r` should show 6.18.24)
- [ ] Roll out to remaining nodes, doing workers one at a time to avoid cluster downtime
- [ ] Confirm the kernel version on all nodes post-deploy: `for h in turtwig chimchar piplup vaporeon flareon glaceon sylveon; do echo "$h: $(ssh oliver@$h.hfym.co uname -r)"; done`

### Notes
- Only `flake.lock` is changed (nixpkgs pin update). No NixOS module or Kubernetes config changes.
- The CVE fix commit upstream: [`a664bf3d603d`](https://git.kernel.org/stable/c/a664bf3d603dc3bdcf9ae47cc21e0daec706d7a5), backported to 6.18 as [`fafe0fa2995a`](https://git.kernel.org/stable/c/fafe0fa2995a0f7073c1c358d7d3145bcc9aedd8) in 6.18.22.
- A public exploit exists: [theori-io/copy-fail-CVE-2026-31431](https://github.com/theori-io/copy-fail-CVE-2026-31431)

Link to Devin session: https://app.devin.ai/sessions/c5880b9c946e486eb72efd631dcb12c8
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
