### PR TITLE
feat: add Devin service account with RBAC for workload management

### DIFF
--- a/kubernetes/users/devin.nix
+++ b/kubernetes/users/devin.nix
@@ -1,18 +1,33 @@
 { ... }:
 
-{
-  namespaces.poketwo.resources = {
-    v1.ServiceAccount.devin = { };
-
-    "rbac.authorization.k8s.io/v1".Role.devin-restart = {
-      rules = [{
-        apiGroups = [ "apps" ];
-        resources = [ "statefulsets" ];
-        verbs = [ "get" "patch" ];
-      }];
+let
+  devinRoleAndBinding = ns: {
+    "rbac.authorization.k8s.io/v1".Role.devin = {
+      rules = [
+        {
+          apiGroups = [ "apps" ];
+          resources = [ "statefulsets" "deployments" ];
+          verbs = [ "get" "list" "patch" ];
+        }
+        {
+          apiGroups = [ "" ];
+          resources = [ "pods" ];
+          verbs = [ "get" "list" "delete" ];
+        }
+        {
+          apiGroups = [ "" ];
+          resources = [ "pods/log" ];
+          verbs = [ "get" ];
+        }
+        {
+          apiGroups = [ "" ];
+          resources = [ "services" "configmaps" "events" ];
+          verbs = [ "get" "list" ];
+        }
+      ];
     };
 
-    "rbac.authorization.k8s.io/v1".RoleBinding.devin-restart = {
+    "rbac.authorization.k8s.io/v1".RoleBinding.devin = {
       subjects = [{
         kind = "ServiceAccount";
         name = "devin";
@@ -20,9 +35,18 @@
       }];
       roleRef = {
         kind = "Role";
-        name = "devin-restart";
+        name = "devin";
         apiGroup = "rbac.authorization.k8s.io";
       };
     };
   };
+in
+{
+  namespaces.poketwo.resources = {
+    v1.ServiceAccount.devin = { };
+  } // devinRoleAndBinding "poketwo";
+
+  namespaces.poketwo-staging.resources = devinRoleAndBinding "poketwo-staging";
+  namespaces.poketwo-staging-private.resources = devinRoleAndBinding "poketwo-staging-private";
+  namespaces.guiduck.resources = devinRoleAndBinding "guiduck";
 }

--- a/kubernetes/users/devin.nix
+++ b/kubernetes/users/devin.nix
@@ -1,0 +1,28 @@
+{ ... }:
+
+{
+  namespaces.poketwo.resources = {
+    v1.ServiceAccount.devin = { };
+
+    "rbac.authorization.k8s.io/v1".Role.devin-restart = {
+      rules = [{
+        apiGroups = [ "" ];
+        resources = [ "pods" ];
+        verbs = [ "get" "list" "delete" ];
+      }];
+    };
+
+    "rbac.authorization.k8s.io/v1".RoleBinding.devin-restart = {
+      subjects = [{
+        kind = "ServiceAccount";
+        name = "devin";
+        namespace = "poketwo";
+      }];
+      roleRef = {
+        kind = "Role";
+        name = "devin-restart";
+        apiGroup = "rbac.authorization.k8s.io";
+      };
+    };
+  };
+}

--- a/kubernetes/users/devin.nix
+++ b/kubernetes/users/devin.nix
@@ -6,9 +6,9 @@
 
     "rbac.authorization.k8s.io/v1".Role.devin-restart = {
       rules = [{
-        apiGroups = [ "" ];
-        resources = [ "pods" ];
-        verbs = [ "get" "list" "delete" ];
+        apiGroups = [ "apps" ];
+        resources = [ "statefulsets" ];
+        verbs = [ "get" "patch" ];
       }];
     };
 


### PR DESCRIPTION
## Summary

Adds a Kubernetes ServiceAccount `devin` in the `poketwo` namespace with RBAC for workload management across four namespaces: `poketwo`, `poketwo-staging`, `poketwo-staging-private`, and `guiduck`.

**Permissions granted per namespace:**

| Resource | Verbs | Purpose |
|----------|-------|---------|
| `statefulsets`, `deployments` | `get`, `list`, `patch` | Update image tags, set replicas, rollout restart |
| `pods` | `get`, `list`, `delete` | View pod status, bulk-delete for fast parallel restart |
| `pods/log` | `get` | Read container logs for debugging |
| `services`, `configmaps`, `events` | `get`, `list` | Read-only debugging context |

**Not granted:** access to secrets, persistent volumes, RBAC resources, or any cluster-level resources.

**Usage after merge + ArgoCD sync:**
```bash
# Generate a long-lived token
kubectl create token devin -n poketwo --duration=8760h

# Restart all pods (parallel recreation via StatefulSet Parallel policy)
kubectl delete pods -l app=poketwo -n poketwo

# Scale down
kubectl patch statefulset poketwo -n poketwo -p '{"spec":{"replicas":0}}'

# Update image tag
kubectl patch statefulset poketwo -n poketwo -p '{"spec":{"template":{"spec":{"containers":[{"name":"poketwo","image":"ghcr.io/poketwo/poketwo:new-branch"}]}}}}'

# View logs
kubectl logs poketwo-0 -n poketwo
```

## Review & Testing Checklist for Human
- [ ] Verify the RBAC scope is acceptable — particularly `patch` on statefulsets/deployments (allows changing image, replicas, annotations, etc.)
- [ ] After merge + ArgoCD sync, generate a token: `kubectl create token devin -n poketwo --duration=8760h`
- [ ] Provide the token + API server address to Devin as an org-scoped secret

### Notes
- The ServiceAccount lives in the `poketwo` namespace; RoleBindings in each target namespace reference it.
- Uses a `let` binding to DRY the Role/RoleBinding across all four namespaces, following the pattern from `witherr.nix`.


Link to Devin session: https://app.devin.ai/sessions/2f590ce79edd4d938c82f18d9c3ae016
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->