### PR TITLE
feat: add Grafana Logs Drilldown, fix SSO role assignment, enable Explore

### DIFF
--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -35,7 +35,6 @@
         "grafana.ini" = {
           server.root_url = "https://grafana.hfym.co";
           explore.enabled = true;
-          users.auto_assign_org_role = "Editor";
           "auth.generic_oauth" = {
             enabled = true;
             name = "Pokétwo";
@@ -46,8 +45,7 @@
             auth_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/auth";
             token_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/token";
             api_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/userinfo";
-            role_attribute_path = "'Editor'";
-            skip_org_role_sync = false;
+            role_attribute_path = "\"'Editor'\"";
           };
         };
 

--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -45,7 +45,7 @@
             auth_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/auth";
             token_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/token";
             api_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/userinfo";
-            role_attribute_path = "\"'Editor'\"";
+            role_attribute_path = "to_string('Editor')";
           };
         };
 

--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -11,6 +11,8 @@
       };
 
       values = {
+        plugins = [ "grafana-lokiexplore-app" ];
+
         admin = {
           existingSecret = "grafana-admin";
           userKey = "admin-user";

--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -35,6 +35,7 @@
         "grafana.ini" = {
           server.root_url = "https://grafana.hfym.co";
           explore.enabled = true;
+          users.auto_assign_org_role = "Editor";
           "auth.generic_oauth" = {
             enabled = true;
             name = "Pokétwo";
@@ -46,6 +47,7 @@
             token_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/token";
             api_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/userinfo";
             role_attribute_path = "'Editor'";
+            skip_org_role_sync = false;
           };
         };
 

--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -34,6 +34,7 @@
 
         "grafana.ini" = {
           server.root_url = "https://grafana.hfym.co";
+          explore.enabled = true;
           "auth.generic_oauth" = {
             enabled = true;
             name = "Pokétwo";

--- a/kubernetes/monitoring/loki.nix
+++ b/kubernetes/monitoring/loki.nix
@@ -52,6 +52,9 @@ in
           limits_config = {
             ingestion_rate_mb = 20;
             ingestion_burst_size_mb = 50;
+            volume_enabled = true;
+            discover_log_levels = true;
+            allow_structured_metadata = true;
           };
 
           analytics.reporting_enabled = false;


### PR DESCRIPTION
## Summary

Three Grafana/Loki fixes:

### 1. Fix SSO users getting Viewer role (`kubernetes/monitoring/grafana.nix`)

**Root cause:** The go-ini parser strips single quotes from INI values. The rendered config had:
```ini
role_attribute_path = 'Editor'
```
go-ini parsed this as the bare string `Editor`, which JMESPath treats as a field lookup on the OAuth token (not a literal). The field doesn't exist → returns null → Grafana falls back to Viewer.

**Fix:** Wrap with double quotes so the INI file becomes `\"'Editor'\"`. go-ini strips the outer double quotes, leaving `'Editor'` — the correct JMESPath literal that returns `\"Editor\"`.

### 2. Install Logs Drilldown plugin + enable Loki backend features

- **Grafana**: Install `grafana-lokiexplore-app` plugin for queryless log browsing
- **Grafana**: Explicitly enable the Explore tab (`explore.enabled = true`)
- **Loki**: Enable `volume_enabled`, `discover_log_levels`, and `allow_structured_metadata` in `limits_config`

## Review & Testing Checklist for Human
- [ ] After ArgoCD syncs, log out and back in via SSO — verify your role is now **Editor** on the profile page (`/profile`)
- [ ] Verify the **Explore** tab appears in the Grafana sidebar
- [ ] Verify the **Logs** entry appears for the Logs Drilldown plugin
- [ ] Open Logs Drilldown and confirm log volumes and level filtering work

### Notes
After merging, you'll need to **log out and back in** via SSO for the role change to take effect. The role sync happens during the OAuth login flow.

Link to Devin session: https://app.devin.ai/sessions/e4d09888b184416e8f09a7c92060e66f
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->