### PR TITLE
fix: use Recreate strategy for Grafana deployment

### DIFF
--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -11,6 +11,8 @@
       };
 
       values = {
+        deploymentStrategy.type = "Recreate";
+
         plugins = [ "grafana-lokiexplore-app" ];
 
         admin = {


### PR DESCRIPTION
## Summary

Sets the Grafana deployment strategy to `Recreate` instead of the default `RollingUpdate`.

Grafana uses a `ReadWriteOnce` PVC for persistence, which can only be mounted by one pod at a time. With the default `RollingUpdate` strategy, the new pod is created before the old one is terminated — but it can't start because the PVC is still held by the old pod. This creates a deadlock: the new pod waits for the volume, and the rollout waits for the new pod to be ready before killing the old one.

`Recreate` terminates the old pod first, releasing the PVC, then starts the new pod. This causes brief downtime during deploys but avoids the multi-attach deadlock.

## Review & Testing Checklist for Human
- [ ] Verify the Grafana pod rolls out cleanly on next ArgoCD sync (no multi-attach errors)

### Notes
The tradeoff is a few seconds of Grafana downtime during deployments, which is acceptable for a single-replica monitoring dashboard.

Link to Devin session: https://app.devin.ai/sessions/e4d09888b184416e8f09a7c92060e66f
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->