### PR TITLE
fix: remove grafana-lokiexplore-app plugin

### DIFF
--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -13,8 +13,6 @@
       values = {
         deploymentStrategy.type = "Recreate";
 
-        plugins = [ "grafana-lokiexplore-app" ];
-
         admin = {
           existingSecret = "grafana-admin";
           userKey = "admin-user";


### PR DESCRIPTION
## Summary

Removes the `grafana-lokiexplore-app` plugin added in #28. The plugin requires Grafana 11.6+ but the chart (8.0.2) ships Grafana 11.0.0, causing an "App not found" error on the Logs page.

The built-in Explore tab (now working with the SSO role fix) with the Loki datasource provides the same log exploration functionality.

## Review & Testing Checklist for Human
- [ ] Verify the "App not found" error on the Logs page is gone after sync

### Notes
The Loki `limits_config` changes (`volume_enabled`, `discover_log_levels`, `allow_structured_metadata`) from #28 are still useful for Loki itself and don't depend on the plugin.

Link to Devin session: https://app.devin.ai/sessions/e4d09888b184416e8f09a7c92060e66f
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->