### PR TITLE
feat: upgrade Grafana chart to 8.13.1 (Grafana 11.6.1) for Logs Drilldown

### DIFF
--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -7,7 +7,7 @@
         repo = "https://grafana.github.io/helm-charts";
         name = "grafana";
         version = "8.13.1";
-        sha256 = "";
+        sha256 = "3fWO2K+nB3qDyAONRm4LI7hdo6YYk+wOfhHCO1Wl7vU=";
       };
 
       values = {

--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -13,8 +13,6 @@
       values = {
         deploymentStrategy.type = "Recreate";
 
-        plugins = [ "grafana-lokiexplore-app" ];
-
         admin = {
           existingSecret = "grafana-admin";
           userKey = "admin-user";

--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -6,8 +6,8 @@
       chart = transpire.fetchFromHelm {
         repo = "https://grafana.github.io/helm-charts";
         name = "grafana";
-        version = "8.0.2";
-        sha256 = "ZavFvU7bKimvNOwCsIi5deO78UXdlWzkMp/6YTPgII4=";
+        version = "8.13.1";
+        sha256 = "";
       };
 
       values = {


### PR DESCRIPTION
## Summary

Upgrades the Grafana Helm chart from **8.0.2** (Grafana 11.0.0) to **8.13.1** (Grafana 11.6.1).

The Logs Drilldown plugin (grafana-lokiexplore-app) requires Grafana 11.6+ and was showing "App not found" with the previous version. Grafana 11.6.1 bundles the plugin natively, so the explicit `plugins` install line is also removed.

Also closes #30 — the plugin removal PR is no longer needed since this chart upgrade fixes the compatibility issue.

## Review & Testing Checklist for Human
- [ ] Verify Grafana pod starts cleanly with the new chart version
- [ ] Verify Logs Drilldown (Explore → Logs) loads without "App not found"
- [ ] Verify Metrics Drilldown (Explore → Metrics) still works
- [ ] Verify SSO login and Editor role still work
- [ ] Check for any breaking changes between Grafana 11.0 → 11.6

### Notes
This is a significant Grafana version jump (11.0 → 11.6). Review the [Grafana release notes](https://grafana.com/docs/grafana/latest/whatsnew/) for any breaking changes that may affect your setup.

Link to Devin session: https://app.devin.ai/sessions/e4d09888b184416e8f09a7c92060e66f
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->