### PR TITLE
fix: null out rollingUpdate for Recreate deployment strategy

### DIFF
--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -11,7 +11,10 @@
       };
 
       values = {
-        deploymentStrategy.type = "Recreate";
+        deploymentStrategy = {
+          type = "Recreate";
+          rollingUpdate = null;
+        };
 
         admin = {
           existingSecret = "grafana-admin";


### PR DESCRIPTION
## Summary

Fixes ArgoCD sync failure:
```
Deployment.apps "grafana" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
```

Kubernetes doesn't allow `rollingUpdate` config when strategy is `Recreate`. The Helm chart sets `rollingUpdate` defaults, so we need to explicitly null it out.

## Review & Testing Checklist for Human
- [ ] Verify ArgoCD sync succeeds and Grafana pod starts cleanly

### Notes
This is a known issue when switching deployment strategy from RollingUpdate to Recreate — see [helm/charts#7437](https://github.com/helm/charts/pull/7437).

Link to Devin session: https://app.devin.ai/sessions/e4d09888b184416e8f09a7c92060e66f
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->