### PR TITLE
fix: re-add grafana-lokiexplore-app plugin for Logs Drilldown

### DIFF
--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -16,6 +16,8 @@
           rollingUpdate = null;
         };
 
+        plugins = [ "grafana-lokiexplore-app" ];
+
         admin = {
           existingSecret = "grafana-admin";
           userKey = "admin-user";


### PR DESCRIPTION
## Summary

Re-adds `grafana-lokiexplore-app` to the Grafana plugins list. The plugin is compatible with Grafana 11.6.1 (upgraded in #31) but still needs explicit installation — it shows the Drilldown → Logs menu item but returns "App not found" without the plugin installed.

## Review & Testing Checklist for Human
- [ ] Verify Drilldown → Logs loads successfully (no "App not found")

### Notes
The Metrics Drilldown works without explicit install because it's fully bundled. The Logs Drilldown apparently still needs the plugin to be installed separately in 11.6.1.

Link to Devin session: https://app.devin.ai/sessions/e4d09888b184416e8f09a7c92060e66f
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->