### PR TITLE
feat: migrate to grafana-community chart 12.0.0 (Grafana 13)

### DIFF
--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -4,10 +4,10 @@
   namespaces.grafana = {
     helmReleases.grafana = {
       chart = transpire.fetchFromHelm {
-        repo = "https://grafana.github.io/helm-charts";
+        repo = "https://grafana-community.github.io/helm-charts";
         name = "grafana";
-        version = "8.13.1";
-        sha256 = "3fWO2K+nB3qDyAONRm4LI7hdo6YYk+wOfhHCO1Wl7vU=";
+        version = "12.0.0";
+        sha256 = "";
       };
 
       values = {
@@ -15,8 +15,6 @@
           type = "Recreate";
           rollingUpdate = null;
         };
-
-        plugins = [ "grafana-lokiexplore-app" ];
 
         admin = {
           existingSecret = "grafana-admin";

--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -7,7 +7,7 @@
         repo = "https://grafana-community.github.io/helm-charts";
         name = "grafana";
         version = "12.0.0";
-        sha256 = "";
+        sha256 = "eqSidrI/OWupasKaL9a9npgwjtB3jCocHBIVjL0SnlM=";
       };
 
       values = {


### PR DESCRIPTION
## Summary

Migrates the Grafana Helm chart from the old `grafana.github.io/helm-charts` repo to the new `grafana-community.github.io/helm-charts` repo, and upgrades from chart 8.13.1 (Grafana 11.6.1) to chart 12.0.0 (Grafana 13.0.0).

This is the [official migration path](https://github.com/grafana/helm-charts/issues/4087) — Grafana moved community-maintained charts to the new repo on Jan 30, 2026.

Changes:
- **Repo URL**: `grafana.github.io` → `grafana-community.github.io`
- **Chart version**: 8.13.1 → 12.0.0
- **Grafana version**: 11.6.1 → 13.0.0
- **Removed explicit `grafana-lokiexplore-app` plugin install** — Grafana 13 bundles all Drilldown apps by default

**Note:** sha256 is intentionally empty for the first CI run to discover the correct hash.

## Review & Testing Checklist for Human
- [ ] Verify Grafana pod starts cleanly with Grafana 13
- [ ] Verify SSO login and Editor role still work (go-ini `to_string` fix should carry over)
- [ ] Verify Drilldown → Logs works without explicit plugin install
- [ ] Verify Drilldown → Metrics still works
- [ ] Verify existing dashboards and datasources load correctly
- [ ] Review [Grafana 12 release notes](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v12-0/) and [Grafana 13 release notes](https://grafana.com/docs/grafana/latest/whatsnew/) for any breaking changes

### Notes
This is a major version jump (11.6 → 13.0). The chart values are fully compatible (same template structure), but Grafana itself may have UI/behavior changes. The chart's only noted breaking change is that Grafana 13 requires an image renderer token, which the chart auto-generates if not provided.

Link to Devin session: https://app.devin.ai/sessions/e4d09888b184416e8f09a7c92060e66f
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->