### PR TITLE
fix: handle null commits in publish workflow

### DIFF
--- a/.github/workflows/kubernetes.yaml
+++ b/.github/workflows/kubernetes.yaml
@@ -63,10 +63,13 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const commits = JSON.parse(process.env.COMMITS);
+            const commits = JSON.parse(process.env.COMMITS) || [];
             const lines = [];
             for (const commit of commits) {
               lines.push(`${commit.id.substring(0, 7)} ${commit.message.split("\n")[0]}`);
+            }
+            if (lines.length == 0) {
+              return `[rebuild] ${context.sha.substring(0, 7)}`;
             }
             if (lines.length == 1) {
               return `[rebuild] ${lines[0]}`;


### PR DESCRIPTION
## Summary

Fixes `TypeError: commits is not iterable` in the `publish` job of the Kubernetes workflow.

`github.event.commits` can be `null` when a PR is merged (the push event payload doesn't always include the commits array). The script was doing `JSON.parse("null")` which returns `null`, then `for (const commit of null)` throws.

Fix: `|| []` to default to an empty array, and a new `lines.length == 0` case that falls back to the commit SHA for the message.

## Review & Testing Checklist for Human
- [ ] After merging, verify the publish job succeeds and pushes to the `cluster` branch

### Notes
This also fixes the blocked Grafana 13 deploy — the previous `publish` run failed on this bug, so the `cluster` branch hasn't been updated with the Grafana 13 chart changes yet. Merging this will trigger a fresh build+publish.

Link to Devin session: https://app.devin.ai/sessions/e4d09888b184416e8f09a7c92060e66f
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->