### PR TITLE
fix: use grafana-community chart 12.0.0 with image tag 13.0.1

### DIFF
--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -7,7 +7,7 @@
         repo = "https://grafana-community.github.io/helm-charts";
         name = "grafana";
         version = "11.6.1";
-        sha256 = "";
+        sha256 = "rFx4qIDTcD5Kt7jFfucZ/lG8VJuIqxESlzDfN8XtyWI=";
       };
 
       values = {

--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -6,11 +6,13 @@
       chart = transpire.fetchFromHelm {
         repo = "https://grafana-community.github.io/helm-charts";
         name = "grafana";
-        version = "11.6.1";
-        sha256 = "rFx4qIDTcD5Kt7jFfucZ/lG8VJuIqxESlzDfN8XtyWI=";
+        version = "12.0.0";
+        sha256 = "eqSidrI/OWupasKaL9a9npgwjtB3jCocHBIVjL0SnlM=";
       };
 
       values = {
+        image.tag = "13.0.1";
+
         deploymentStrategy = {
           type = "Recreate";
           rollingUpdate = null;

--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -6,8 +6,8 @@
       chart = transpire.fetchFromHelm {
         repo = "https://grafana-community.github.io/helm-charts";
         name = "grafana";
-        version = "12.0.0";
-        sha256 = "eqSidrI/OWupasKaL9a9npgwjtB3jCocHBIVjL0SnlM=";
+        version = "11.6.1";
+        sha256 = "";
       };
 
       values = {


### PR DESCRIPTION
## Summary

Chart 12.0.0 ships `appVersion: 13.0.0`, but `grafana/grafana:13.0.0` was never published as a stable Docker tag — Grafana skipped straight to `13.0.1`. This caused `ImagePullBackOff` on the Grafana pod.

Fix: keep chart 12.0.0 but override `image.tag` to `13.0.1` (the first stable Grafana 13 release on Docker Hub).

## Review & Testing Checklist for Human
- [ ] Verify Grafana pod starts and image pulls successfully
- [ ] Verify SSO login still gives Editor role
- [ ] Verify Drilldown → Logs and Metrics both work

### Notes
`13.0.1` was pushed to Docker Hub 21 days ago and is the latest stable 13.x tag.

Link to Devin session: https://app.devin.ai/sessions/e4d09888b184416e8f09a7c92060e66f
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->