### PR TITLE
feat: upgrade Loki chart to 6.55.0 (Loki 3.6.7)

### DIFF
--- a/kubernetes/monitoring/loki.nix
+++ b/kubernetes/monitoring/loki.nix
@@ -16,7 +16,7 @@ in
         repo = "https://grafana.github.io/helm-charts";
         name = "loki";
         version = "6.55.0";
-        sha256 = "";
+        sha256 = "5IgdiiPetXqJy4+sycIeauTEWq8TOg0XkQ1vGDhSXrY=";
       };
 
       values = {

--- a/kubernetes/monitoring/loki.nix
+++ b/kubernetes/monitoring/loki.nix
@@ -15,8 +15,8 @@ in
       chart = transpire.fetchFromHelm {
         repo = "https://grafana.github.io/helm-charts";
         name = "loki";
-        version = "6.6.3";
-        sha256 = "lsfiXnoZRf8rSmAeyD5BzpPOEGdCj79hFxzmCa9ae6A=";
+        version = "6.55.0";
+        sha256 = "";
       };
 
       values = {


### PR DESCRIPTION
## Summary

Upgrades the Loki Helm chart from **6.6.3** (Loki 3.0.0) to **6.55.0** (Loki 3.6.7).

This is a major version bump that fixes the Grafana 13 Logs Drilldown "Log volume has not been configured" error. The issue is that Grafana 13's Logs Drilldown calls `/loki/api/v1/config/drilldown` to check volume support, and this endpoint didn't exist in Loki 3.0.0 (added in ~3.4). Despite `volume_enabled = true` being configured, the 404 response causes Drilldown to assume volume is disabled.

Loki 3.6.7 also includes many performance improvements since 3.0.0.

**Note:** sha256 is intentionally empty for the first CI run to discover the correct hash.

## Review & Testing Checklist for Human
- [ ] Verify Loki pods restart cleanly after ArgoCD sync (this is a major Loki version jump — 3.0.0 → 3.6.7)
- [ ] Check that Logs Drilldown no longer shows "Log volume has not been configured"
- [ ] Verify log ingestion and querying still works
- [ ] Check for any breaking changes in Loki 3.x release notes that could affect the current setup
- [ ] Monitor Loki pod resource usage after upgrade — newer versions may have different resource profiles

### Notes
This is a significant upgrade spanning many Loki releases. The Helm values structure should be compatible since we're staying within chart major version 6.x. The last 6.x chart release is 6.55.0 — the chart has since moved to the grafana-community repo for 7.x+.

Link to Devin session: https://app.devin.ai/sessions/e4d09888b184416e8f09a7c92060e66f
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->