### PR TITLE
fix: enable IPv6 for Loki query-frontend address discovery

### DIFF
--- a/kubernetes/monitoring/loki.nix
+++ b/kubernetes/monitoring/loki.nix
@@ -72,6 +72,7 @@ in
           query_scheduler.scheduler_ring.instance_enable_ipv6 = true;
           query_scheduler.scheduler_ring.kvstore.store = "memberlist";
           ruler.ring.kvstore.store = "memberlist";
+          frontend.instance_enable_ipv6 = true;
           memberlist.bind_addr = [ "::" ];
         };
 


### PR DESCRIPTION
## Summary

Adds `frontend.instance_enable_ipv6 = true` to Loki's structuredConfig. After the Loki 3.0.0 → 3.6.7 upgrade (PR #37), the `loki-read` pods are crash-looping with:

```
no useable address found for interfaces [eth0 en0 lo]
failed to get frontend address
```

The query-frontend V2 has its own `instance_enable_ipv6` flag separate from the ring components. The rings already had IPv6 enabled, but the frontend was missed because Loki 3.0.0 didn't use this code path.

## Review & Testing Checklist for Human

- [ ] Verify `loki-read` pods start successfully after ArgoCD sync
- [ ] Verify Logs Drilldown in Grafana no longer shows \"Log volume has not been configured\"

### Notes

One-line config change. The `drilldown-limits` 404 in Grafana should also resolve once Loki is back up, since that endpoint exists in Loki 3.6.7 but was unreachable due to the crash-loop.

Link to Devin session: https://app.devin.ai/sessions/e4d09888b184416e8f09a7c92060e66f
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->