### PR TITLE
perf: increase Loki read replicas from 1 to 3

### DIFF
--- a/kubernetes/monitoring/loki.nix
+++ b/kubernetes/monitoring/loki.nix
@@ -87,7 +87,7 @@ in
         };
 
         read = withEnv {
-          replicas = 1;
+          replicas = 3;
           # resources = {
           #   limits = { memory = "4Gi"; };
           #   requests = { cpu = "100m"; memory = "128Mi"; };


### PR DESCRIPTION
## Summary

Increases Loki read replicas from 1 to 3 to improve query parallelism. The Poketwo Logs dashboard runs ~10 concurrent Loki queries, each doing JSON parsing across all 200 pods over a 1-hour window. With only 1 read replica, these queries are serialized.

## Review & Testing Checklist for Human

- [ ] Check that `loki-read` pods scale to 3 after ArgoCD sync
- [ ] Verify the [Poketwo Logs dashboard](https://grafana.hfym.co/d/efh2zb4og3oqod/poketwo-logs) loads faster

### Notes

This is the quick win. A more structural optimization would be promoting the `event` field to a Loki label at ingestion time (via Alloy relabeling) to avoid JSON parsing at query time.

Link to Devin session: https://app.devin.ai/sessions/e4d09888b184416e8f09a7c92060e66f
Requested by: @oliver-ni