### PR TITLE
perf: extract level and event as Loki structured metadata in Alloy

### DIFF
--- a/kubernetes/monitoring/alloy/config.alloy
+++ b/kubernetes/monitoring/alloy/config.alloy
@@ -51,8 +51,24 @@ discovery.relabel "pods" {
 
 loki.source.kubernetes "pods" {
   targets = discovery.relabel.pods.output
-  forward_to = [loki.write.default.receiver]
+  forward_to = [loki.process.default.receiver]
   clustering { enabled = true }
+}
+
+loki.process "default" {
+  stage.json {
+    expressions = {
+      level = "level",
+      event = "event",
+    }
+  }
+  stage.structured_metadata {
+    values = {
+      level = "",
+      event = "",
+    }
+  }
+  forward_to = [loki.write.default.receiver]
 }
 
 loki.source.kubernetes_events "default" {


### PR DESCRIPTION
## Summary

Adds a `loki.process` pipeline stage to Alloy that extracts `level` and `event` fields from JSON log lines as [Loki structured metadata](https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/). This allows Loki queries to filter by these fields without parsing every log line as JSON at query time.

**Before:** Every panel on the Poketwo Logs dashboard runs `| json | __error__="" | event="pokemon_spawned"` which scans and parses every log line.

**After:** `level` and `event` are attached as structured metadata at ingestion time. Queries can filter on them directly without `| json`, and Loki can skip non-matching log chunks more efficiently.

The change is backward compatible — existing queries with `| json` continue to work. Non-JSON logs pass through the `stage.json` step unaffected (extraction simply yields empty values which are not stored).

## Review & Testing Checklist for Human

- [ ] Verify Alloy pods restart without errors after sync
- [ ] In Grafana Logs Drilldown, check that new log entries show `level` and `event` in the structured metadata section (visible in the log line detail view)
- [ ] Test that the [Poketwo Logs dashboard](https://grafana.hfym.co/d/efh2zb4og3oqod/poketwo-logs) still loads correctly
- [ ] Optionally, update dashboard queries to remove `| json` for even faster performance (not required — backward compatible)

### Notes

Only newly ingested logs will have structured metadata attached. Historical logs that were ingested before this change will still require `| json` parsing. Over time (as old logs age out), all queries will benefit.

Link to Devin session: https://app.devin.ai/sessions/e4d09888b184416e8f09a7c92060e66f
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->