### PR TITLE
feat: map SSO users to Admin role in Grafana

### DIFF
--- a/kubernetes/monitoring/grafana.nix
+++ b/kubernetes/monitoring/grafana.nix
@@ -50,7 +50,7 @@
             auth_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/auth";
             token_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/token";
             api_url = "https://auth-dev.poketwo.io/realms/poketwo/protocol/openid-connect/userinfo";
-            role_attribute_path = "to_string('Editor')";
+            role_attribute_path = "to_string('Admin')";
           };
         };
 


### PR DESCRIPTION
## Summary
Changes the Grafana OIDC `role_attribute_path` from `Editor` to `Admin` so that SSO-authenticated users get the Admin role, enabling service account management and other admin features.

## Review & Testing Checklist for Human
- [ ] After ArgoCD syncs, log in to [Grafana](https://grafana.hfym.co) via SSO and verify you have Admin permissions
- [ ] Confirm you can create service accounts under Administration → Service accounts

### Notes
Single-line change in `kubernetes/monitoring/grafana.nix`.

Link to Devin session: https://app.devin.ai/sessions/f95a86e87179422aa3c29177aa909a34
Requested by: @oliver-ni