### PR TITLE
feat: advertise MetalLB CIDR via Tailscale subnet router

### DIFF
--- a/kubernetes/core/tailscale-operator.nix
+++ b/kubernetes/core/tailscale-operator.nix
@@ -34,10 +34,13 @@
       };
     };
 
-    # Subnet router for Kubernetes service CIDR
+    # Subnet router for Kubernetes service + MetalLB CIDRs
     resources."tailscale.com/v1alpha1".Connector.k8s-subnet-router.spec = {
       subnetRouter = {
-        advertiseRoutes = [ "2606:c2c0:5:1:2::/112" ];
+        advertiseRoutes = [
+          "2606:c2c0:5:1:2::/112"
+          "2606:c2c0:5:1:3::/112"
+        ];
       };
     };
   };


### PR DESCRIPTION
## Summary
Add `2606:c2c0:5:1:3::/112` (MetalLB LoadBalancer pool) to the Tailscale Connector's advertised routes alongside the existing service CIDR (`2606:c2c0:5:1:2::/112`).

This allows tailnet clients (e.g. Devin) to reach LoadBalancer services directly — specifically MongoDB external access endpoints whose replica set config advertises the MetalLB LB IPs as member addresses.

## Review & Testing Checklist for Human
- [ ] After ArgoCD syncs, verify the Tailscale Connector is advertising both routes: check `tailscale status --json` from a tailnet client and confirm `2606:c2c0:5:1:3::/112` appears in the subnet router's AllowedIPs
- [ ] Test MongoDB connectivity from a tailnet client using the existing `mongodb-*-external.poketwo.ds.hfym.co` hostnames

### Notes
The service CIDR (`2606:c2c0:5:1:2::/112`) was already advertised, which allows reaching ClusterIP services. However, MongoDB's replica set configuration tells clients to reconnect using the MetalLB LB IPs (`2606:c2c0:5:1:3::4`, `2606:c2c0:5:1:3::5`), so the MetalLB CIDR also needs to be routable through the tailnet.

Link to Devin session: https://app.devin.ai/sessions/8e76ff83afd64001b9a258e81e837f5b
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->