### PR TITLE
feat: advertise pod CIDRs via Tailscale subnet router

### DIFF
--- a/kubernetes/core/tailscale-operator.nix
+++ b/kubernetes/core/tailscale-operator.nix
@@ -38,8 +38,13 @@
     resources."tailscale.com/v1alpha1".Connector.k8s-subnet-router.spec = {
       subnetRouter = {
         advertiseRoutes = [
-          "2606:c2c0:5:1:2::/112"
-          "2606:c2c0:5:1:3::/112"
+          "2606:c2c0:5:1:2::/112" # Service CIDR
+          "2606:c2c0:5:1:3::/112" # MetalLB CIDR
+          "2606:c2c0:5:1:128::/80" # Pod CIDR (vaporeon)
+          "2606:c2c0:5:1:129::/80" # Pod CIDR (jolteon)
+          "2606:c2c0:5:1:130::/80" # Pod CIDR (flareon)
+          "2606:c2c0:5:1:131::/80" # Pod CIDR (glaceon)
+          "2606:c2c0:5:1:132::/80" # Pod CIDR (sylveon)
         ];
       };
     };


### PR DESCRIPTION
## Summary
Adds the per-worker-node pod CIDRs to the Tailscale subnet router's `advertiseRoutes`, so that pod IPs are reachable from the tailnet — not just ClusterIP and MetalLB addresses.

Previously only the service CIDR (`2606:c2c0:5:1:2::/112`) and MetalLB CIDR (`2606:c2c0:5:1:3::/112`) were advertised. Headless services (e.g. `mongodb-headless`) resolve to pod IPs, which were unreachable from Tailscale clients.

Added pod CIDRs:
- `2606:c2c0:5:1:128::/80` (vaporeon)
- `2606:c2c0:5:1:129::/80` (jolteon)
- `2606:c2c0:5:1:130::/80` (flareon)
- `2606:c2c0:5:1:131::/80` (glaceon)
- `2606:c2c0:5:1:132::/80` (sylveon)

## Review & Testing Checklist for Human
- [ ] Verify the Tailscale subnet router pod restarts and the new routes appear in the Tailscale admin console
- [ ] Test that headless service DNS (e.g. `mongodb-headless.poketwo.svc.ds.hfym.co`) resolves to pod IPs and those IPs are now reachable from a tailnet client
- [ ] Confirm existing ClusterIP and MetalLB service access still works

### Notes
The control plane nodes (turtwig, chimchar, piplup) are on Linode with different address ranges and typically don't run workload pods, so their CIDRs are not included.

Link to Devin session: https://app.devin.ai/sessions/6a6e31cfd5694c5f84250b75318d737e
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/nix/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->